### PR TITLE
Yas Backsolve Feature

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4577,6 +4577,478 @@ keep them in future yasnippet versions and other elisp libraries
 can more or less safely rely upon them.")
 
 
+;;; Snippet backsolving functionality
+
+;; Regex Constants
+(defconst yas--free-text-group-regex
+  "\\(.*\\)" 
+  "A regexp to match free text entry from a snippit. Does not
+recognize new line")
+
+(defconst yas--prefix-group-regex
+    "\\([ \t]*\\)"
+  "A regexp to match stuff at the start of the of each line of
+  the template regex.")
+
+(defconst yas--any-char-regex
+    "\\([[:unibyte:]]*?\\)"
+  "A regexp to match arbitrary unlimited characters but in a
+  non-greedy way.")
+
+(defconst yas--blank-line-regex
+  "^[ \t]*$"
+  "Regex to match a single blank line")
+
+(defconst yas--whitespace-regex
+  "[ \t]*"
+  "Regex to match whitespace")
+       
+;; Functions 
+(defun ljj--get-regex-groups (string regex) 
+  "Extracts the match groups from a regex match on a string"
+  (string-match regex string)
+  (setq return ())
+  (setq count 1)
+  (while (setq match (match-string count string))
+    (setq return (append  return (list match)))
+    (setq count (1+ count)))
+  return)
+
+(defun yas--template-to-regex (templateStr)
+  "Take a snippet template string and transform it into a regular
+expression capable of searching"
+  ;; First create a snippet from the template.
+  (let ((snippet (yas--make-snippet))
+        count
+        (exit-flag 'nil)
+        return
+        curr-buffer)
+    
+    ;; Create buffer to do parsing in
+    (setq temp-buffer (generate-new-buffer-name "temp-buffer"))
+    (get-buffer-create temp-buffer)
+    (setq curr-buffer (current-buffer))
+    (set-buffer temp-buffer)
+    (text-mode)                         ; Use an inoculous mode to parse the snippet in
+    (insert templateStr)
+    (goto-char (point-min))
+
+    ;; Parse the template
+    (yas--snippet-parse-create-no-indent snippet)
+
+    ;; Sort and link each field
+    (yas--snippet-sort-fields-by-start snippet)
+
+    ;; Get the fields variable
+    (setq fields (yas--snippet-fields snippet))
+
+    ;; Replace regex chars with regular text (eg . -> \. and ] -> \])
+    (yas--buffer-to-regex)    
+
+    ;; Special consideration is needed for the exit location
+    ;; regex. Here we check if the snippet specifies one at all:
+    (if (not (yas--snippet-exit snippet))
+        (setq exit-flag 't))
+    
+    ;; Loop on the fields
+    (setq count 2)
+    (dolist (field fields)
+      ;; First check if we have passed by the $0 marker
+      (if (not exit-flag)
+          (if (> (yas--field-start field)
+                 (yas--exit-marker (yas--snippet-exit snippet)))
+              (progn
+               ;; Insert a regex marger for $0
+               (goto-char (yas--exit-marker (yas--snippet-exit snippet)))
+               (insert-before-markers yas--any-char-regex)
+               ;; Add the count to the return object
+               (setq count (+ count 1))
+               ;; Indicate that we have marked the exit regex
+               (setq exit-flag 't))))
+      
+      ;; Replace the text for each field with a matchgroup regex
+      (delete-region (yas--field-start field)
+                     (yas--field-end field))
+      (goto-char (yas--field-start field))
+      (insert-before-markers yas--free-text-group-regex)
+      
+      ;; Replace the mirror fields with a mirror regex. eg \1, \2, etc.
+      (dolist (mirror (yas--field-mirrors field))
+        (delete-region (yas--mirror-start mirror)
+                       (yas--mirror-end mirror))
+        (goto-char (yas--mirror-start mirror))
+        (insert-before-markers "\\")
+        (insert-before-markers (number-to-string count)))
+      (setq count (+ count 1)))
+
+    ;; If we never passed the $0 marker, we handle it here.
+    (if (not exit-flag)
+        (progn
+         ;; Insert a regex marger for $0
+         (goto-char (yas--exit-marker (yas--snippet-exit snippet)))
+         (insert-before-markers yas--any-char-regex)
+         ;; Add the count to the return object
+         (setq count (+ count 1))
+         ;; Indicate that we have marked the exit regex
+         (setq exit-flag 't)))
+    
+    ;; insert line prefixes. First line prefix is a free text match
+    ;; group. All other lines mirror this match. This means that
+    ;; however much white space appears before the first line must
+    ;; also appear before subsequent lines.
+    (yas--buffer-add-line-prefixes yas--prefix-group-regex "\\1" nil)
+
+    ;; Replace blank lines with white space regex
+    (goto-char (point-min))
+    (while (re-search-forward yas--blank-line-regex nil t)
+      ;; replace the match
+      (replace-match yas--whitespace-regex))
+    
+    ;; Get regex string to return
+    (setq return (buffer-substring (point-min) (point-max)))
+
+    ;; Switch back to current buffer
+    (switch-to-buffer curr-buffer)
+    
+    ;; Kill the child buffer
+    (kill-buffer temp-buffer)
+
+    ;; Decrement yas-snippt-id-seed to hide the creation of the
+    ;; snippet in the temp buffer. Otherwise, the id will count
+    ;; upwards when it should not.
+    (yas--snippet-previous-id)
+    
+    ;; Return the regex object
+    return))
+
+(defun yas--buffer-to-regex ()
+  "This function transforms buffer into a regex that exactly
+matches the buffer. This has the effect of changing all special
+regex symbols to include a break character if needed. Thus
+'[asdf]' would be transformed to '\[asdf]' and so on.
+
+Because the buffer has markers in it which need to be saved, we
+cannot simply replace the buffer string with a string generated
+by regexp-quote. Instead, we create 'string' with
+regexp-quote (which is always longer) and scan through the
+buffers adding characters as needed."
+  (save-excursion
+    (let (string index) 
+      (setq string (buffer-substring (point-min) (point-max)))
+      (setq string (regexp-quote string)) ; Generate the regexp string
+      (goto-char (point-min))             ; set position to 0
+      (setq index 0)                      ; set index to 0
+
+      ;; Scan through buffer and replace insert chars when there is a
+      ;; discrepancy between the buffer and string.
+      (while (< (point) (point-max)) 
+        (if (equal (elt string index) (char-after (point)))
+            (goto-char (+ (point) 1))
+          (insert (elt string index)))
+        (setq index (+ index 1))))))
+
+(defun yas--line-is-blank ()
+  "determine if line at point is empty or not. Empty here means
+  line contains only whitespace chars."
+  (save-excursion
+    (let ((start-line (line-number-at-pos)))
+      ;; If we match on the regex compare line numbers otherwise
+      ;; return nil.
+      (if (re-search-forward yas--blank-line-regex nil t)
+          (= start-line (line-number-at-pos))
+        nil))))
+
+(defun yas--buffer-add-line-prefixes (firstLine laterLines markAll)
+  "Add prefix regular expressions to the start of each line of
+  the buffer. The first line of the buffer will be prefixed by
+  The string \"firstLine\". All remaining lines will be prefixed
+  by the string \"laterLines\". Blank lines are ignored if
+  markAll is nil. The first line is always marked even if blank."
+
+  (save-excursion
+    (let (index max)
+
+      ;; Insert the first line prefix
+      (goto-char (point-min))
+      (insert-before-markers firstLine)
+      
+      ;; Insert later lines prefixes
+      (forward-line)
+      (setq index 1)
+      (setq max (count-lines (point-min) (point-max)))
+      (while (< index max)
+        (beginning-of-line)
+        (if (or markAll (not (yas--line-is-blank)))
+            (insert-before-markers laterLines))
+        (forward-line)
+        (setq index (+ 1 index))))))
+
+(defun yas--fill-template (templateStr groups)
+  "Take a template string and fill in fields with the strings in
+  \"groups\"."
+  ;; First create a snippet from the template.
+
+  (let ((snippet (yas--make-snippet))
+        count
+        offset
+        (exit-flag 'nil))
+    
+    ;; Create buffer to do parsing in
+    (setq start (point))
+    (insert templateStr)
+
+    ;; Narow
+    (save-restriction
+      (narrow-to-region start (point))
+      (goto-char (point-min))
+      
+      ;; Parse the template
+      (yas--snippet-parse-create-no-indent snippet)
+
+      ;; Create keymap overlay for snippet
+      (setf (yas--snippet-control-overlay snippet)
+            (yas--make-control-overlay snippet (point-min) (point-max)))
+
+      ;; Insert first match group at beginning of each line
+      (yas--buffer-add-line-prefixes (nth 0 groups) (nth 0 groups) t)
+      
+      ;; Sort "by start" order:
+      (yas--snippet-sort-fields-by-start snippet)
+      
+      ;; Special consideration is needed for the exit location
+      ;; regex. Here we check if the snippet specifies one at all:
+      (if (not (yas--snippet-exit snippet))
+          (setq exit-flag 't))
+      
+      ;; Insert correct values before sorting (skipping the first value
+      ;; in groups)
+      (setq count 0)
+      (setq offset 1)
+      (while (setq field (nth count (yas--snippet-fields snippet)))
+        ;; First check if we have passed by the $0 marker
+        (if (not exit-flag)
+            (if (> (yas--field-start field) (yas--exit-marker (yas--snippet-exit snippet)))
+                (progn
+                  ;; Insert a regex marker for $0
+                  (goto-char (yas--exit-marker (yas--snippet-exit snippet)))
+                  (insert (nth (+ count offset) groups))
+                  ;; Add the count to the return object
+                  (setq offset (+ offset 1))
+                  ;; Indicate that we have marked the exit regex
+                  (setq exit-flag 't))))
+        
+        ;; Now enter group text into the current field
+        (yas--move-to-field snippet field)
+        (insert (nth (+ count offset) groups))
+        (setq count (+ count offset)))
+
+      ;; First check if we have passed by the $0 marker
+      (if (not exit-flag)
+          (progn
+            ;; Insert a regex marker for $0
+            (goto-char (yas--exit-marker (yas--snippet-exit snippet)))
+            (insert (nth (+ count offset) groups))
+            ;; Add the count to the return object
+            (setq offset (+ offset 1))
+            ;; Indicate that we have marked the exit regex
+            (setq exit-flag 't)))
+      
+      ;; Sort fields
+      (yas--snippet-sort-fields snippet)
+      
+      ;; Exit the snippet immediately if no fields
+      (unless (yas--snippet-fields snippet)
+        (yas-exit-snippet snippet))
+
+      ;; Now, schedule a move to the first field
+      (let ((first-field (car (yas--snippet-fields snippet))))
+        (when first-field
+          (yas--move-to-field snippet first-field))))))
+
+(defun yas--snippet-sort-fields-by-start (snippet)
+  "Sort the fields of SNIPPET in navigation order."
+  (setf (yas--snippet-fields snippet)
+        (sort (yas--snippet-fields snippet)
+              #'yas--snippet-field-compare-by-start)))
+
+(defun yas--snippet-field-compare-by-start (field1 field2)
+  "Compare through the field's start point"
+  (< (yas--field-start field1)
+     (yas--field-start field2)))
+
+(defun yas--match-and-revive (templateStr)
+  "Function which takes a snippet template and 1. Searches for a
+  match in buffer 2. Extracts the match groups 3. removes the
+  match region and 4. Replaces region with filled template.
+
+  Returns t if the search for a match is successful and nil
+  otherwise."
+  
+  (let ((regex (yas--template-to-regex templateStr)) (groups nil) (start) (end))
+    (if (re-search-forward regex nil t)
+        (progn
+          (setq start (match-beginning 0))
+          (setq end (match-end 0))
+          (setq groups
+                (ljj--get-regex-groups
+                 (buffer-substring start end)
+                 regex))
+          ;; Remove region starting at end of first match group. This leaves
+          ;; any prefix white-space present to prevent indentation being
+          ;; effected.
+          (delete-region start end)
+          (yas--fill-template templateStr groups)
+          t)
+      nil)))
+
+(defun yas--get-templates-from-key (key)
+  "Return a list of templates based on a key."
+  (mapcar #'(lambda (temp)
+              (cdr temp))
+          (mapcan #'(lambda (table)
+                      (yas--fetch table key))
+                  (yas--get-snippet-tables))))
+
+(defun yas--snippet-parse-create-no-indent (snippet)
+  "Parse a recently inserted snippet template, creating all
+necessary fields, mirrors and exit points.
+
+Meant to be called in a narrowed buffer, does various passes
+
+This is the same as yas--snippet-parse-create but skips the final
+indent step. This is hack to prevent bad format changing
+issues. Perhaps modify yas--snippet-parse-create in the future to
+have an option to skip the indentation process."
+  (let ((parse-start (point)))
+    ;; Reset the yas--dollar-regions
+    ;;
+    (setq yas--dollar-regions nil)
+    ;; protect just the backquotes
+    ;;
+    (yas--protect-escapes nil '(?`))
+    ;; replace all backquoted expressions
+    ;;
+    (goto-char parse-start)
+    (yas--save-backquotes)
+    ;; protect escaped characters
+    ;;
+    (yas--protect-escapes)
+    ;; parse fields with {}
+    ;;
+    (goto-char parse-start)
+    (yas--field-parse-create snippet)
+    ;; parse simple mirrors and fields
+    ;;
+    (goto-char parse-start)
+    (yas--simple-mirror-parse-create snippet)
+    ;; parse mirror transforms
+    ;;
+    (goto-char parse-start)
+    (yas--transform-mirror-parse-create snippet)
+    ;; calculate adjacencies of fields and mirrors
+    ;;
+    (yas--calculate-adjacencies snippet)
+    ;; Delete $-constructs
+    ;;
+    (save-restriction (widen) (yas--delete-regions yas--dollar-regions))
+    ;; restore backquoted expression values
+    ;;
+    (yas--restore-backquotes)
+    ;; restore escapes
+    ;;
+    (goto-char parse-start)
+    (yas--restore-escapes)
+    ;; update mirrors for the first time
+    ;;
+    (yas--update-mirrors snippet)
+    ;; indent the best we can
+    ;;
+    (goto-char parse-start)
+    ;; (yas--indent snippet)
+    ))
+
+(defun yas--snippet-previous-id ()
+  "Function to decrement the yas--snippet-id-seed. This is used
+  when you wish to create a snippet without the user being aware
+  of it. The only place this is used so far is in
+  yas--template-to-regex."
+  (cl-incf yas--snippet-id-seed -1))
+
+(defun yas--snippet-is-simple (templateStr)
+  "Returns t if the snippet has no tranformation fields and no
+  transformation mirrors. We refer to this type of snippet as
+  simple."
+  
+  (let ((snippet (yas--make-snippet))
+        return
+        field
+        mirror
+        curr-buffer)
+
+    ;; Default return value to t.
+    (setq return t)
+    
+    ;; Create buffer to do parsing in
+    (setq temp-buffer (generate-new-buffer-name "temp-buffer"))
+    (get-buffer-create temp-buffer)
+    (setq curr-buffer (current-buffer))
+    (set-buffer temp-buffer)
+    (text-mode)                         ; Use an inoculous mode to parse the snippet in
+    (insert templateStr)
+    (goto-char (point-min))
+    
+    ;; Parse create the snippet
+    (yas--snippet-parse-create-no-indent snippet)
+
+    ;; Loop on fields
+    (dolist (field (yas--snippet-fields snippet))
+      ;; If field is not simple, nil the return value.
+      (if (yas--apply-transform field field t)
+          (setq return nil))
+      ;; Subloop on mirrors
+      (dolist (mirror (yas--field-mirrors field))
+        ;; If mirror is not simple, nil the return value.
+        (if (yas--apply-transform mirror field t)
+            (setq return nil))))
+    
+    ;; Switch back to current buffer
+    (switch-to-buffer curr-buffer)
+    
+    ;; Kill the child buffer
+    (kill-buffer temp-buffer)
+
+    ;; reset snippet count
+    (yas--snippet-previous-id)
+    
+    ;; Return the result
+    return))
+
+(defun yas-backsolve ()
+  "This is the interactive function to revive a snippet. \"key\"
+  is the same key witch launches the snippet"
+  (interactive)
+  (let ((templatesByKey)
+        (templateStr)
+        (key (yas-completing-prompt "Key: " (yas-active-keys))))
+    ;; Get all templates by key
+    (setq templatesByKey (yas--get-templates-from-key key))
+    ;; If zero are found do nothing and message an error (this should
+    ;; never happen)
+    (if (null templatesByKey) (message "Key not found!")
+      ;; If one is found, match and revive
+      (if (= 1 (length templatesByKey))         
+          (setq templateStr (yas--template-content (nth 0 templatesByKey)))
+        ;; If multiple are found, prompt to choose
+        (setq templateStr
+         (yas--template-content
+          (yas--prompt-for-template templatesByKey "Choose a template: "))))
+      ;; Check if the snippet is simple
+      (if (yas--snippet-is-simple templateStr)
+          (if (not (yas--match-and-revive templateStr))
+              (message "Backsolve not found for given key!"))
+        (message "This snippet format is not yet supported by yas-backsolve!")))))
+
+
 (provide 'yasnippet)
 ;; Local Variables:
 ;; coding: utf-8


### PR DESCRIPTION
# INTRO

This pull request is regarding some new functionality I have been experimenting with for yasnippet. I thought you might like to take a look and see if it is something that you would want to eventually add to yasnippet. If you are interested in this development, we can discuss how best to eventually integrate it into the master branch. Any and all feedback is welcome.
# IDEA

The idea is to add "back solving" capability. This means that text created with a snippet can be re-initialized and re-edited as a snippet. Even text was not created using a snippet can be "back solved". The one new interative function in my branch is "yas-backsolve". It will prompt for snippet key and then search forward for a snippet to re-activate.
# WHY?

A couple examples of the use case where I like to use yas-backsolve in my own work. Suppose I use the c++ snippet with key "fori":

```
for (${1:auto }${2:it} = ${3:var}.begin(); $2 != $3.end(); ++$2) {
    $0
}
```

to create the code

```
for (auto myIterator = myVector.begin(); myIterator != myVector.end(); ++myIterator) {
    myValue += *myIterator;
}
```

and I later want to change the name myIterator to yourIterator and myVector to yourVector. Running yas-backsolve on the the key "fori" re-activates the snippet as if I had just created it (with field names preserved) and I can tab through and edit the names fields and the changes will update in all the mirrors. It does not matter if this for loop code was created using a snippet in the first place. yas-backsolve will still work.

Another place I use yas-backsolve is with the latex snippet with key "begin":

```
\begin{${1:env}}
  $0
\end{$1}
```

Suppose I open a latex file and it looks like

```
\begin{enumerate}
  \item thing one
  \item 
    \begin{center}
      thing two
    \end{center}
  \item thing three
\end{enumerate}
```

I can run yas-backsolve with key begin to re-enter the snippet used to create the "enumerate" environment and change it to "itemize". The text in the "begin" and "end" will be updated simultaneously.

Once a person is comfortable using basic yasnippets, yas-backsolve feels very natural since it uses the same UI.
# HOW?

yas-backsolve works by utilizing regular expressions to figure out what text was inserted into the fields of a snippet. Once given a snippet key, yas-backsolve converts the snippet into a regular expression capable of searching for text that looks like it was created using the snippet corresponding to the key. If it finds a match, it extracts text that was entered into the fields of the snippet. Using this information, yas-backsolve initializes the matched text as if it were a snippet begin edited.

yas-backsolve does not store any metadata associated with files. Snippets are not cached in any way. This way I can edit a file I have opened for the first time as if snippets had been used in its creation.
# WHAT NOW?

yas-backsolve has some known limitations. Currently it works only on snippets with simple non-nested mirror fileds. Snippets using lisp expressions in their fields or mirrors will not work properly. yas-backsolve attempts to determine before running if the input snippet is compatible and notifies the user accordingly. Over time, I intend to expand the functionality of yas-backsolve to overcome these limiations.

I am sharing what I have now to get some feedback on what areas I should focus on first if there is interest in including this functionality into yasnippet. Any comments regarding features, UI, and coding style are all welcome.
