### PR TITLE
Snippet local exit hooks

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -553,6 +553,36 @@ TODO: correct this bug!"
                      "brother from another mother") ;; no newline should be here!
             )))
 
+(ert-deftest snippet-exit-hooks ()
+  (defvar yas--ran-exit-hook)
+  (with-temp-buffer
+    (yas-saving-variables
+     (let ((yas--ran-exit-hook nil)
+           (yas-triggers-in-field t))
+       (yas-with-snippet-dirs
+         '((".emacs.d/snippets"
+            ("emacs-lisp-mode"
+             ("foo" . "\
+# expand-env: ((yas-after-exit-snippet-hook (lambda () (setq yas--ran-exit-hook t))))
+# --
+FOO ${1:f1} ${2:f2}")
+             ("sub" . "\
+# expand-env: ((yas-after-exit-snippet-hook (lambda () (setq yas--ran-exit-hook 'sub))))
+# --
+SUB"))))
+         (yas-reload-all)
+         (emacs-lisp-mode)
+         (yas-minor-mode +1)
+         (insert "foo")
+         (ert-simulate-command '(yas-expand))
+         (should-not yas--ran-exit-hook)
+         (yas-mock-insert "sub")
+         (ert-simulate-command '(yas-expand))
+         (ert-simulate-command '(yas-next-field))
+         (should-not yas--ran-exit-hook)
+         (ert-simulate-command '(yas-next-field))
+         (should (eq yas--ran-exit-hook t)))))))
+
 (defvar yas--barbaz)
 (defvar yas--foobarbaz)
 

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1345,8 +1345,7 @@ Returns (TEMPLATES START END). This function respects
       ((debug error) (cdr oops)))))
 
 (defun yas--eval-for-effect (form)
-  ;; FIXME: simulating lexical-binding.
-  (yas--safely-run-hook `(lambda () ,form)))
+  (yas--safely-run-hook (apply-partially #'eval form)))
 
 (defun yas--read-lisp (string &optional nil-on-error)
   "Read STRING as a elisp expression and return it.
@@ -1755,8 +1754,7 @@ With prefix argument USE-JIT do jit-loading of snippets."
         ;;
         (yas--define-parents mode-sym parents)
         (yas--menu-keymap-get-create mode-sym)
-        (let ((fun `(lambda () ;; FIXME: Simulating lexical-binding.
-                      (yas--load-directory-1 ',dir ',mode-sym))))
+        (let ((fun (apply-partially #'yas--load-directory-1 dir mode-sym)))
           (if use-jit
               (yas--schedule-jit mode-sym fun)
             (funcall fun)))

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1344,7 +1344,6 @@ Returns (TEMPLATES START END). This function respects
     (if (memq yas-good-grace '(t inline))
         (condition-case oops
             (funcall eval-saving-stuff form)
-          (yas--exception (signal 'yas-exception (cdr oops)))
           (error (cdr oops)))
       (funcall eval-saving-stuff form))))
 
@@ -2855,17 +2854,16 @@ The last element of POSSIBILITIES may be a list of strings."
             key)))))
 
 (defun yas-throw (text)
-  "Throw a yas--exception with TEXT as the reason."
-  (signal 'yas--exception text))
-(put 'yas--exception 'error-conditions '(error yas--exception))
+  "Signal `yas-exception' with TEXT as the reason."
+  (signal 'yas-exception (list text)))
+(put 'yas-exception 'error-conditions '(error yas-exception))
+(put 'yas-exception 'error-message "[yas] Exception")
 
 (defun yas-verify-value (possibilities)
   "Verify that the current field value is in POSSIBILITIES.
-
-Otherwise throw exception."
-  (when (and yas-moving-away-p
-             (cl-notany (lambda (pos) (string= pos yas-text)) possibilities))
-    (yas-throw (yas--format "Field only allows %s" possibilities))))
+Otherwise signal `yas-exception'."
+  (when (and yas-moving-away-p (cl-notany (lambda (pos) (string= pos yas-text)) possibilities))
+    (yas-throw (format "Field only allows %s" possibilities))))
 
 (defun yas-field-value (number)
   "Get the string for field with NUMBER.


### PR DESCRIPTION
Close #28.

The example there would be

``` elisp
(defun yas-delete (regexp)
  (goto-char yas-snippet-beg)
  (while (re-search-forward regexp yas-snippet-end t)
    (replace-match "")))
```

```
#name : mock
#key : mock
#expand-env: ((yas-after-exit-snippet-hook (lambda () (yas-delete "\\.[a-zA-Z0-9]+(IGNORE)"))))
# --
${1:mock} = mock()
$1.expects(:${2:method}).with(${3:IGNORE}).returns(${4:IGNORE}).times(${5:IGNORE})
```
