### PR TITLE
Update 'capitaomorte' links to use 'joaotavora'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
         branch = master
 [submodule "yasmate"]
         path = yasmate
-        url = https://github.com/capitaomorte/yasmate.git
+        url = https://github.com/joaotavora/yasmate.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,4 +26,4 @@ there is no separate Changelog file.
 For trivial changes, a message consisting of just the changelog entry
 (the `* foo.el ...` part) is fine.
 
-[bugnote]: https://github.com/capitaomorte/yasnippet#important-note-regarding-bug-reporting
+[bugnote]: https://github.com/joaotavora/yasnippet#important-note-regarding-bug-reporting

--- a/NEWS
+++ b/NEWS
@@ -53,7 +53,7 @@ good enough.  See issue #497.
 
 *** Documentation rewritten in org-mode and updated.
 A tremendous effort by Noam Postavsky.  Hopefully easier to maintain
-and navigate.  Available at <http://capitaomorte.github.io/yasnippet>.
+and navigate.  Available at <http://joaotavora.github.io/yasnippet>.
 
 *** Snippets are now maintained in their own repo.
 Snippets live in Andrea Crotti's
@@ -61,7 +61,7 @@ Snippets live in Andrea Crotti's
 for more details.
 
 *** Textmate snippet importer moved to separate `yasmate' repo.
-URL is <https://github.com/capitaomorte/yasmate>.  See README.md for
+URL is <https://github.com/joaotavora/yasmate>.  See README.md for
 more details.
 
 *** `yas-snippet-dirs' now allows symbols as aliases to directories.

--- a/README.mdown
+++ b/README.mdown
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/capitaomorte/yasnippet.png)](https://travis-ci.org/capitaomorte/yasnippet)
+[![Build Status](https://travis-ci.org/joaotavora/yasnippet.png)](https://travis-ci.org/joaotavora/yasnippet)
 
 # Intro
 
@@ -20,7 +20,7 @@ YASnippet. Watch [a demo on YouTube][youtube-demo].
 Clone this repository somewhere
 
     $ cd ~/.emacs.d/plugins
-    $ git clone --recursive https://github.com/capitaomorte/yasnippet
+    $ git clone --recursive https://github.com/joaotavora/yasnippet
 
 Add the following in your `.emacs` file:
 
@@ -124,7 +124,7 @@ reproducing a bug.
 $ emacs --version
 Emacs 24.3
 $ cd /tmp/
-$ git clone https://github.com/capitaomorte/yasnippet.git yasnippet-bug
+$ git clone https://github.com/joaotavora/yasnippet.git yasnippet-bug
 $ cd yasnippet-bug
 $ git log -1 --oneline
 6053db0 Closes #527: Unbreak case where yas-fallback-behaviour is a list
@@ -142,7 +142,7 @@ Using `emacs -Q` or temporarily moving your `.emacs` init file to the side
 is another way to achieve good reproducibility.
 
 Here's a
-[another example](https://github.com/capitaomorte/yasnippet/issues/318)
+[another example](https://github.com/joaotavora/yasnippet/issues/318)
 of a bug report. It has everything needed for a successful analysis
 and speedy resolution.
 
@@ -161,11 +161,11 @@ request).
 
 Finally, thank you very much for using YASnippet!
 
-[docs]: http://capitaomorte.github.com/yasnippet/
-[issues]: https://github.com/capitaomorte/yasnippet/issues
+[docs]: http://joaotavora.github.com/yasnippet/
+[issues]: https://github.com/joaotavora/yasnippet/issues
 [googlecode tracker]: http://code.google.com/p/yasnippet/issues/list
 [forum]: http://groups.google.com/group/smart-snippet
 [melpa]: http://melpa.milkbox.net/
-[yasmate]: http://github.com/capitaomorte/yasmate
+[yasmate]: http://github.com/joaotavora/yasmate
 [textmate-to-yas.el]: https://github.com/mattfidler/textmate-to-yas.el
 [yasnippet-snippets]: http://github.com/AndreaCrotti/yasnippet-snippets

--- a/doc/index.org
+++ b/doc/index.org
@@ -3,7 +3,7 @@
 
 The YASnippet documentation has been split into separate parts:
 
-0. [[https://github.com/capitaomorte/yasnippet/blob/master/README.mdown][README]]
+0. [[https://github.com/joaotavora/yasnippet/blob/master/README.mdown][README]]
 
    Contains an introduction, installation instructions and other important
    notes.

--- a/doc/nav-menu.html.inc
+++ b/doc/nav-menu.html.inc
@@ -1,7 +1,7 @@
 <nav>
   <ul class="center">
     <li> <a href="index.html">Overview</a>
-    <li> <a href="https://github.com/capitaomorte/yasnippet/blob/master/README.mdown">
+    <li> <a href="https://github.com/joaotavora/yasnippet/blob/master/README.mdown">
         Intro and Tutorial</a>
     <li class="center">Snippet
       <ul>

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -6,9 +6,9 @@
 ;;          Noam Postavsky <npostavs@gmail.com>
 ;; Maintainer: Noam Postavsky <npostavs@gmail.com>
 ;; Version: 0.9.1
-;; X-URL: http://github.com/capitaomorte/yasnippet
+;; X-URL: http://github.com/joaotavora/yasnippet
 ;; Keywords: convenience, emulation
-;; URL: http://github.com/capitaomorte/yasnippet
+;; URL: http://github.com/joaotavora/yasnippet
 ;; Package-Requires: ((cl-lib "0.5"))
 ;; EmacsWiki: YaSnippetMode
 
@@ -127,7 +127,7 @@
 ;;   `custom-set-variables' is executed in your .emacs file.
 ;;
 ;;   For more information and detailed usage, refer to the project page:
-;;      http://github.com/capitaomorte/yasnippet
+;;      http://github.com/joaotavora/yasnippet
 
 ;;; Code:
 


### PR DESCRIPTION
Various links were being redirected (or not working) due to the use of
this older name.