### PR TITLE
Remove the key bindings of overridden templates correctly

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1083,7 +1083,7 @@ Has the following fields:
         (maphash #'(lambda (k v)
                      (let ((template (gethash name v)))
                        (when (and template
-                                  (eq uuid (yas--template-uuid template)))
+                                  (equal uuid (yas--template-uuid template)))
                          (remhash name v)
                          (when (zerop (hash-table-count v))
                            (push k empty-keys)))))


### PR DESCRIPTION
When loading a second template with the same uuid, the previous template must be removed from the database including its key binding.  However, removing the previous template from namehashes and then from keyhash seems not working, leaving it intact and still expandable.

This fixes the current implementation of `yas--remove-template-by-uuid` where the uuid equality is tested with `eq` instead of `equal`.