### PR TITLE
Don't clobber match data in modification hooks

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3416,14 +3416,15 @@ field start.  This hook does nothing if an undo is in progress."
     (let* ((inhibit-modification-hooks t)
            (field (overlay-get overlay 'yas--field))
            (snippet (overlay-get yas--active-field-overlay 'yas--snippet)))
-      (when (yas--skip-and-clear-field-p field beg end length)
-        ;; We delete text starting from the END of insertion.
-        (yas--skip-and-clear field end))
-      (setf (yas--field-modified-p field) t)
-      (yas--advance-end-maybe field (overlay-end overlay))
-      (save-excursion
-        (yas--field-update-display field))
-      (yas--update-mirrors snippet))))
+      (save-match-data
+        (when (yas--skip-and-clear-field-p field beg end length)
+          ;; We delete text starting from the END of insertion.
+          (yas--skip-and-clear field end))
+        (setf (yas--field-modified-p field) t)
+        (yas--advance-end-maybe field (overlay-end overlay))
+        (save-excursion
+          (yas--field-update-display field))
+        (yas--update-mirrors snippet)))))
 
 ;;; Apropos protection overlays:
 ;;


### PR DESCRIPTION
Fixes #720.
```
Since modification hooks run just after any function that changes buffer
contents, it's important to save the match data, or else the code doing
the modification can become really confused.  See also Emacs bugs #23917
and #23869.

* yasnippet.el (yas--on-field-overlay-modification): Wrap main body in
`save-match-data'.
```