### PR TITLE
Fixes missing python-in-string/comment errors

### DIFF
--- a/doc/snippet-expansion.org
+++ b/doc/snippet-expansion.org
@@ -193,11 +193,11 @@ block or a string (e.g. in =python-mode=).
 
 If you use the =# condition := directive (see
 [[./snippet-development.org][Writing Snippets]]) you could just specify
-the condition for =if= to be =(not (python-in-string/comment))=. But how
+the condition for =if= to be =(not (python-syntax-comment-or-string-p))=. But how
 about =while=, =for=, etc. ? Writing the same condition for all the
 snippets is just boring. So has a buffer local variable
 [[sym:yas-buffer-local-condition][=yas-buffer-local-condition=]]. You can set this variable to
-=(not (python-in-string/comment))= in =python-mode-hook=.
+=(not (python-syntax-comment-or-string-p))= in =python-mode-hook=.
 
 Then, what if you really want some particular snippet to expand even
 inside a comment? Set [[sym:yas-buffer-local-condition][=yas-buffer-local-condition=]] like this
@@ -206,7 +206,7 @@ inside a comment? Set [[sym:yas-buffer-local-condition][=yas-buffer-local-condit
   (add-hook 'python-mode-hook
             (lambda ()
               (setq yas-buffer-local-condition
-                    '(if (python-in-string/comment)
+                    '(if (python-syntax-comment-or-string-p)
                          '(require-snippet-condition . force-in-comment)
                        t))))
 #+END_SRC

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -522,7 +522,7 @@ conditions.
  (add-hook \\='python-mode-hook
            (lambda ()
               (setq yas-buffer-local-condition
-                    \\='(if (python-in-string/comment)
+                    \\='(if (python-syntax-comment-or-string-p)
                          \\='(require-snippet-condition . force-in-comment)
                        t))))
 


### PR DESCRIPTION
python.el renames python-in-string/comment to python-syntax-comment-or-string-p
This commit modifies the documentation to reflect that.