### PR TITLE
Fix saving of new snippets

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2600,7 +2600,8 @@ and `kill-buffer' instead."
         (unless (or buffer-file-name (not default-file-name))
           (setq buffer-file-name
                 (read-file-name "File to save snippet in: "
-                                nil nil nil default-file-name )))
+                                nil nil nil default-file-name))
+          (rename-buffer (file-name-nondirectory buffer-file-name) t))
         (save-buffer)))
     (quit-window kill)))
 


### PR DESCRIPTION
Fixes #733.

```
`buffer-file-name' is a permanent buffer-local variable, so if we reuse
the "*new snippet*" buffer, we could end up visiting the last new
snippet's file.

* yasnippet.el (yas-load-snippet-buffer-and-close): Rename the "*new
snippet*" buffer when making it visit a file.
```