### PR TITLE
Respect yas-indent-line for mirror updates

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4303,10 +4303,11 @@ When multiple expressions are found, only the last one counts."
         (yas--advance-start-maybe (yas--mirror-next mirror) (point))
         ;; super-special advance
         (yas--advance-end-of-parents-maybe mirror-parent-field (point)))
-      (let ((yas--inhibit-overlay-hooks t))
-        (yas--indent-region (yas--mirror-start mirror)
-                            (yas--mirror-end mirror)
-                            snippet)))))
+      (when (eq yas-indent-line 'auto)
+        (let ((yas--inhibit-overlay-hooks t))
+          (yas--indent-region (yas--mirror-start mirror)
+                              (yas--mirror-end mirror)
+                              snippet))))))
 
 (defun yas--field-update-display (field)
   "Much like `yas--mirror-update-display', but for fields."


### PR DESCRIPTION
```
* yasnippet.el (yas--mirror-update-display): Check yas-indent-line
before indenting.
```

Fixes #739. ~~but this doesn't help if only the snippet binds `yas-indent-line`, because the snippet's `expand-env` is only in effect during the initial expansion. Have to think about whether/how to apply it later.~~ This might affect #702 implementation too.
