### PR TITLE
Let snippets expand in strings/comments by default

### DIFF
--- a/doc/snippet-expansion.org
+++ b/doc/snippet-expansion.org
@@ -181,8 +181,9 @@ In particular, the following things matter:
 -  Buffer-local [[sym:yas-buffer-local-condition][=yas-buffer-local-condition=]] variable
 
    This variable provides finer grained control over what snippets can
-   be expanded in the current buffer.  You could disable snippet
-   expansion inside comments or string literals for example.  See [[condition-system][the
+   be expanded in the current buffer.  For example, the constant
+   [[sym:yas-not-string-or-comment-condition][=yas-not-string-or-comment-condition=]] has a value that disables
+   snippet expansion inside comments or string literals.  See [[condition-system][the
    condition system]] for more info.
 
 ** The condition system <<condition-system>>

--- a/doc/snippet-expansion.org
+++ b/doc/snippet-expansion.org
@@ -178,32 +178,29 @@ In particular, the following things matter:
                 (yas-activate-extra-mode 'rails-mode)))
 #+END_SRC
 
--  Buffer-local
-   [[sym:yas-buffer-local-condition][=yas-buffer-local-condition=]]
-   variable
+-  Buffer-local [[sym:yas-buffer-local-condition][=yas-buffer-local-condition=]] variable
 
    This variable provides finer grained control over what snippets can
-   be expanded in the current buffer. The default value won't let you
-   expand snippets inside comments or string literals for example. See
-   The condition system\_ for more info.
+   be expanded in the current buffer.  You could disable snippet
+   expansion inside comments or string literals for example.  See [[condition-system][the
+   condition system]] for more info.
 
-** The condition system
+** The condition system <<condition-system>>
 
 Consider this scenario: you are an old Emacs hacker. You like the
 abbrev-way and bind [[sym:yas-expand][=yas-expand=]] to =SPC=. However, you don't want
 =if= to be expanded as a snippet when you are typing in a comment
 block or a string (e.g. in =python-mode=).
 
-If you use the =# condition := directive (see
-[[./snippet-development.org][Writing Snippets]]) you could just specify
-the condition for =if= to be =(not (python-syntax-comment-or-string-p))=. But how
-about =while=, =for=, etc. ? Writing the same condition for all the
-snippets is just boring. So has a buffer local variable
-[[sym:yas-buffer-local-condition][=yas-buffer-local-condition=]]. You can set this variable to
-=(not (python-syntax-comment-or-string-p))= in =python-mode-hook=.
+If you use the =# condition := directive (see [[./snippet-development.org][Writing Snippets]]) you
+could just specify the condition for =if= to be =(not
+(python-syntax-comment-or-string-p))=.  But how about =while=, =for=,
+etc?  Writing the same condition for all the snippets is just boring.
+So you can instead set [[sym:yas-buffer-local-condition][=yas-buffer-local-condition=]] to =(not
+(python-syntax-comment-or-string-p))= in =python-mode-hook=.
 
 Then, what if you really want some particular snippet to expand even
-inside a comment? Set [[sym:yas-buffer-local-condition][=yas-buffer-local-condition=]] like this
+inside a comment?  Set [[sym:yas-buffer-local-condition][=yas-buffer-local-condition=]] like this
 
 #+BEGIN_SRC emacs-lisp
   (add-hook 'python-mode-hook
@@ -214,10 +211,10 @@ inside a comment? Set [[sym:yas-buffer-local-condition][=yas-buffer-local-condit
                        t))))
 #+END_SRC
 
-... and specify the condition for a snippet that you're going to expand
-in comment to be evaluated to the symbol =force-in-comment=. Then it can
-be expanded as you expected, while other snippets like =if= still can't
-expanded in comment.
+... and for a snippet that you want to expand in comments, specify a
+condition which evaluates to the symbol =force-in-comment=.  Then it
+can be expanded as you expected, while other snippets like =if= still
+can't expanded in comments.
 
 For the full set of possible conditions, see the documentation for
 [[sym:yas-buffer-local-condition][=yas-buffer-local-condition=]].

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -456,7 +456,17 @@ Attention: These hooks are not run when exiting nested/stacked snippet expansion
   '()
   "Hooks to run just before expanding a snippet.")
 
-(defvar yas-buffer-local-condition t
+(defconst yas-not-string-or-comment-condition
+  '(if (and (let ((ppss (syntax-ppss)))
+              (or (nth 3 ppss) (nth 4 ppss)))
+            (memq this-command '(yas-expand yas-expand-from-trigger-key
+                                            yas-expand-from-keymap)))
+       '(require-snippet-condition . force-in-comment)
+     t)
+  "Disables snippet expansion in strings and comments.
+To use, set `yas-buffer-local-condition' to this value.")
+
+(defcustom yas-buffer-local-condition t
   "Snippet expanding condition.
 
 This variable is a Lisp form which is evaluated every time a
@@ -503,7 +513,15 @@ conditions.
               (setq yas-buffer-local-condition
                     \\='(if (python-syntax-comment-or-string-p)
                          \\='(require-snippet-condition . force-in-comment)
-                       t))))")
+                       t))))"
+  :type
+  `(choice
+    (const :tag "Disable snippet expansion inside strings and comments"
+           ,yas-not-string-or-comment-condition)
+    (const :tag "Expand all snippets regardless of conditions" always)
+    (const :tag "Expand snippets unless their condition is nil" t)
+    (const :tag "Disable all snippet expansion" nil)
+    sexp))
 
 
 ;;; Internal variables

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -456,13 +456,7 @@ Attention: These hooks are not run when exiting nested/stacked snippet expansion
   '()
   "Hooks to run just before expanding a snippet.")
 
-(defvar yas-buffer-local-condition
-  '(if (and (let ((ppss (syntax-ppss)))
-              (or (nth 3 ppss) (nth 4 ppss)))
-            (memq this-command '(yas-expand yas-expand-from-trigger-key
-                                            yas-expand-from-keymap)))
-       '(require-snippet-condition . force-in-comment)
-     t)
+(defvar yas-buffer-local-condition t
   "Snippet expanding condition.
 
 This variable is a Lisp form which is evaluated every time a
@@ -509,12 +503,7 @@ conditions.
               (setq yas-buffer-local-condition
                     \\='(if (python-syntax-comment-or-string-p)
                          \\='(require-snippet-condition . force-in-comment)
-                       t))))
-
-The default value is similar, it filters out potential snippet
-expansions inside comments and string literals, unless the
-snippet itself contains a condition that returns the symbol
-`force-in-comment'.")
+                       t))))")
 
 
 ;;; Internal variables


### PR DESCRIPTION
See https://github.com/joaotavora/yasnippet/pull/638#issue-121831941:

> the condition was effectively ignored for a long time due to only checking `yas-expand-from-trigger-key` and not `yas-expand`, I wonder if people will start complaining that snippets no longer work in comments...

It did happen, so I'm changing the default to `t`.

Close #765.
Close #773.
Close #772.
Also #706.

```
* yasnippet.el (yas-buffer-local-condition): Change default to t.
* doc/snippet-expansion.org: Update documentation.
```