### PR TITLE
Fix mirror transformation error with expand-env

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -614,6 +614,26 @@ foobaz\n"))))
          (should (eq 'global (nth 0 yas--ran-exit-hook)))
          (should (eq 'local (nth 1 yas--ran-exit-hook))))))))
 
+(ert-deftest snippet-mirror-bindings ()
+  "Check that variables defined with the expand-env field are
+accessible from mirror transformations."
+  (with-temp-buffer
+    (yas-saving-variables
+     (let ((yas-triggers-in-field t)
+           (yas-good-grace nil))
+       (yas-with-snippet-dirs
+         '((".emacs.d/snippets"
+            ("emacs-lisp-mode"
+             ("baz" . "\
+# expand-env: ((func #'upcase))
+# --
+hello ${1:$(when (stringp yas-text) (funcall func yas-text))} foo${1:$$(concat \"baz\")}$0"))))
+         (yas-reload-all)
+         (emacs-lisp-mode)
+         (yas-minor-mode +1)
+         (insert "baz")
+         (ert-simulate-command '(yas-expand))
+         (should (string= (yas--buffer-contents) "hello BAZ foobaz\n")))))))
 
 (defvar yas--barbaz)
 (defvar yas--foobarbaz)

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3731,7 +3731,8 @@ considered when expanding the snippet."
            (let ((first-field (car (yas--snippet-fields snippet))))
              (when first-field
                (sit-for 0) ;; fix issue 125
-               (yas--move-to-field snippet first-field)))
+               (yas--letenv (yas--snippet-expand-env snippet)
+                 (yas--move-to-field snippet first-field))))
            (yas--message 4 "snippet expanded.")
            t))))
 


### PR DESCRIPTION
* yasnippet.el (yas-expand-snippet): Use the snippet lexical binding
  when moving field. This prevents getting an error when calling a
  function variable defined in expand-env.

* yasnippet-tests.el (snippet-mirror-bindings): Add a test to check if
  we can call a function variable defined in the snippet environment.

Note: I also saw there could be a bug (not related to that patch). If the mirror transformation doesn't contain any character before (at indentation), blank spaces after the mirror will be removed. This is because the mirror transformation may return `""`.