### PR TITLE
Debugging improvements

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,12 @@ task :tests do
     " --batch -f ert-run-tests-batch-and-exit"
 end
 
+desc "run test in interactive mode"
+task :itests do
+  sh "#{$EMACS} -Q -L . -l yasnippet-tests.el" +
+     " --eval \"(call-interactively 'ert)\""
+end
+
 desc "create a release package"
 task :package do
   release_dir = "pkg/yasnippet-#{$version}"

--- a/yasnippet-debug.el
+++ b/yasnippet-debug.el
@@ -192,6 +192,12 @@
 
 (defvar yas-debug-target-buffer nil)
 (defvar-local yas-debug-target-snippets nil)
+(defvar yas-debug-undo nil)
+
+(defun yas-toggle-debug-undo (value)
+  (interactive (list (not yas-debug-undo)))
+  (setq yas-debug-undo value)
+  (yas--message 3 "debug undo %sabled" (if yas-debug-undo "en" "dis")))
 
 (defadvice yas--snippet-parse-create (before yas-debug-target-snippet (snippet))
   (add-to-list 'yas-debug-target-snippets snippet))
@@ -223,7 +229,11 @@
                        (unless (memq loc yas-debug-recently-live-indicators)
                          (delete-overlay (cdr color-ov))
                          (remhash loc yas-debug-live-indicators)))
-                     yas-debug-live-indicators)))
+                     yas-debug-live-indicators))
+          (when (and yas-debug-undo (listp buffer-undo-list))
+            (printf "Undo list has %s elements:\n" (length buffer-undo-list))
+            (cl-loop for undo-elem in buffer-undo-list
+                     do (printf "%S\n" undo-elem))))
         (when hook
           (setq yas-debug-target-buffer (current-buffer))
           (ad-enable-advice 'yas--snippet-parse-create 'before 'yas-debug-target-snippet)

--- a/yasnippet-debug.el
+++ b/yasnippet-debug.el
@@ -167,8 +167,9 @@
               (yas-debug-live-range overlay)))
     (when-let (active-field (yas--snippet-active-field snippet))
       (unless (consp (yas--field-start active-field))
-        (printf "\tactive field: #%d %s covering \"%s\"\n"
+        (printf "\tactive field: #%d %s %s covering \"%s\"\n"
                 (yas--field-number active-field)
+                (if (yas--field-modified-p active-field) "**" "--")
                 (yas-debug-live-range active-field)
                 (buffer-substring-no-properties (yas--field-start active-field) (yas--field-end active-field)))))
     (when-let (exit (yas--snippet-exit snippet))
@@ -177,8 +178,9 @@
               (yas--exit-next exit)))
     (dolist (field (yas--snippet-fields snippet))
       (unless (consp (yas--field-start field))
-        (printf "\tfield: %d %s covering \"%s\" next: %s%s\n"
+        (printf "\tfield: %d %s %s covering \"%s\" next: %s%s\n"
                 (yas--field-number field)
+                (if (yas--field-modified-p field) "**" "--")
                 (yas-debug-live-range field)
                 (buffer-substring-no-properties (yas--field-start field) (yas--field-end field))
                 (yas--debug-format-fom-concise (yas--field-next field))

--- a/yasnippet-debug.el
+++ b/yasnippet-debug.el
@@ -288,18 +288,19 @@
            (format "snippet exit at %d"
                    (marker-position (yas--fom-start fom)))))))
 
-(defun yas-debug-process-command-line ()
+(defun yas-debug-process-command-line (&optional options)
   "Implement command line processing."
   (setq yas-verbosity 99)
   (setq yas-triggers-in-field t)
   (setq debug-on-error t)
   (let* ((snippet-file nil)
          (snippet-mode 'fundamental-mode)
-         (options (cl-loop for opt = (pop command-line-args-left)
-                           while (and opt (not (equal opt "--"))
-                                      (string-prefix-p "-" opt))
-                           collect opt))
          (snippet-key nil))
+    (unless options
+      (setq options (cl-loop for opt = (pop command-line-args-left)
+                             while (and opt (not (equal opt "--"))
+                                        (string-prefix-p "-" opt))
+                             collect opt)))
     (when-let (mode (cl-member "-M:" options :test #'string-prefix-p))
       (setq snippet-mode (intern (concat (substring (car mode) 3) "-mode"))))
     (when-let (mode (cl-member "-M." options :test #'string-prefix-p))


### PR DESCRIPTION
`yasnippet-debug.el` can now be used to quickly test and debug a snippet
in a file.