### PR TITLE
Don't delete snippets more than once.

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3580,6 +3580,11 @@ field start.  This hook does nothing if an undo is in progress."
   (unless (or (not after?)
               yas--inhibit-overlay-hooks
               (not (overlayp yas--active-field-overlay)) ; Avoid Emacs bug #21824.
+              ;; If a single change hits multiple overlays of the same
+              ;; snippet, then we delete the snippet the first time,
+              ;; and then subsequent calls get a deleted overlay.
+              ;; Don't delete the snippet again!
+              (not (overlay-buffer overlay))
               (yas--undo-in-progress))
     (let* ((inhibit-modification-hooks nil)
            (yas--inhibit-overlay-hooks t)


### PR DESCRIPTION
Fixes #814.
```
* yasnippet.el (yas--on-field-overlay-modification): Don't commit
snippet again if the the triggering overlay has already been deleted.
```