### PR TITLE
Fix compilation warnings, add compile_all to standard test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,18 @@ git:
   submodules: false
 
 env:
-  - EMACS_VERSION=23.4
-  - EMACS_VERSION=24.3
-  - EMACS_VERSION=24.5
-  - EMACS_VERSION=25.2
+  global:
+    - Wlexical=t
+    - Werror=t
+    - tests_Werror=t # For yasnippet-tests.el
+  matrix:
+    - EMACS_VERSION=23.4
+    # 24.3 gives a bunch of 'value returned from (car value-N) is
+    # unused' warnings.
+    - EMACS_VERSION=24.3 tests_Werror=nil
+    - EMACS_VERSION=24.5
+    - EMACS_VERSION=25.2
+
 
 install:
   - curl -LO https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz
@@ -15,7 +23,7 @@ install:
   # Configure $PATH: Emacs installed to /tmp/emacs
   - export PATH=/tmp/emacs/bin:${PATH}
   - if ! emacs -Q --batch --eval "(require 'cl-lib)" ; then
-        curl -Lo cl-lib.el http://elpa.gnu.org/packages/cl-lib-0.5.el ;
+        curl -Lo cl-lib.el http://elpa.gnu.org/packages/cl-lib-0.6.1.el ;
         export warnings="'(not cl-functions)" ;
     fi
   - if ! emacs -Q --batch --eval "(require 'ert)" ; then
@@ -25,7 +33,9 @@ install:
   - emacs --version
 
 script:
-  - rake compile
+  - rake yasnippet.elc
+  - rake yasnippet-debug.elc
+  - rake yasnippet-tests.elc Werror=$tests_Werror
   - rake tests
 
 notifications:

--- a/Rakefile
+++ b/Rakefile
@@ -100,14 +100,22 @@ end
 desc "Compile yasnippet.el into yasnippet.elc"
 
 rule '.elc' => '.el' do |t|
-  set_warnings = ""
+  cmdline = $EMACS + ' --batch -L .'
   if ENV['warnings']
-    set_warnings = " --eval \"(setq byte-compile-warnings #{ENV['warnings']})\""
+    cmdline += " --eval \"(setq byte-compile-warnings #{ENV['warnings']})\""
   end
-  sh "#{$EMACS} --batch -L . --eval \"(setq byte-compile-error-on-warn t)\"" +
-     "#{set_warnings} -f batch-byte-compile #{t.source}"
+  if ENV['Werror']
+    cmdline += " --eval \"(setq byte-compile-error-on-warn #{ENV['Werror']})\""
+  end
+  if ENV['Wlexical']
+    cmdline += " --eval \"(setq byte-compile-force-lexical-warnings #{ENV['Wlexical']})\""
+  end
+  cmdline +=" -f batch-byte-compile #{t.source}"
+
+  sh cmdline
 end
 task :compile => FileList["yasnippet.el"].ext('elc')
+task :compile_all => FileList["*.el"].ext('elc')
 
 task :default => :doc
 

--- a/yasnippet-debug.el
+++ b/yasnippet-debug.el
@@ -91,8 +91,7 @@
           (puthash location (cons color ov) yas-debug-live-indicators)))))
 
 (defun yas-debug-live-marker (marker)
-  (let* ((buffer (current-buffer))
-         (color-ov (yas-debug-get-live-indicator marker))
+  (let* ((color-ov (yas-debug-get-live-indicator marker))
          (color (car color-ov))
          (ov (cdr color-ov))
          (decorator (overlay-get ov 'before-string))
@@ -100,7 +99,7 @@
     (if (markerp marker)
         (propertize str
                     'cursor-sensor-functions
-                    `(,(lambda (window _oldpos dir)
+                    `(,(lambda (_window _oldpos dir)
                          (overlay-put
                           ov 'before-string
                           (propertize decorator
@@ -129,7 +128,7 @@
     (if (and beg end (not (integerp beg)) (not (integerp end)))
         (propertize (format "from %d to %d" (+ beg) (+ end))
                     'cursor-sensor-functions
-                    `(,(lambda (window _oldpos dir)
+                    `(,(lambda (_window _oldpos dir)
                          (let ((face (if (eq dir 'entered)
                                          'mode-line-highlight color)))
                            (overlay-put ov 'before-string
@@ -271,7 +270,7 @@
     (printf "%s overlays in buffer:\n\n" (length (overlays-in (point-min) (point-max))))
     (printf "%s live snippets at point:\n\n" (length (yas-active-snippets)))
 
-    (yas-debug-snippets outbuf)
+    (yas-debug-snippets outbuf) ;;FIXME: reference to free variable ‘outbuf’
 
     (printf "\nUndo is %s and point-max is %s.\n"
             (if (eq buffer-undo-list t)
@@ -286,7 +285,7 @@
         (dolist (undo-elem first-ten)
           (printf "%2s:  %s\n" (cl-position undo-elem first-ten)
                   (truncate-string-to-width (format "%s" undo-elem) 70)))))
-    (display-buffer tracebuf)))
+    (display-buffer tracebuf))) ;;FIXME: reference to free variable ‘tracebuf’
 
 (defun yas--debug-format-fom-concise (fom)
   (when fom
@@ -308,8 +307,7 @@
   (setq yas-verbosity 99)
   (setq yas-triggers-in-field t)
   (setq debug-on-error t)
-  (let* ((snippet-file nil)
-         (snippet-mode 'fundamental-mode)
+  (let* ((snippet-mode 'fundamental-mode)
          (snippet-key nil))
     (unless options
       (setq options (cl-loop for opt = (pop command-line-args-left)


### PR DESCRIPTION
I'll probably need to release 0.12.1 with this soon, since users are going to see a bunch of (actually harmless) compile errors when installing.