### PR TITLE
Avoid to indent snippets having setup `(yas-indent-line 'fixed)`

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3635,7 +3635,10 @@ field start.  This hook does nothing if an undo is in progress."
         (narrow-to-region beg end)
         (mapc #'yas--restore-marker-location remarkers)
         (mapc #'yas--restore-overlay-location reoverlays))
-      (mapc #'yas--update-mirrors snippets))))
+      (mapc (lambda (snippet)
+              (yas--letenv (yas--snippet-expand-env snippet)
+                (yas--update-mirrors snippet)))
+            snippets))))
 
 
 ;;; Apropos protection overlays:


### PR DESCRIPTION
Avoid `yas--auto-fill` call `yas--update-mirrors` without setting the snippet environment.

When an snippet like the one bellow is expanded and that auto-fill-mode is activated, the snippet is re-indented when you press space in a field replacement.

```snippet
# -*- mode: snippet; coding: utf-8-unix -*-
# name: fctb - function ... return boolean
# key: fctb
# expand-env: ((yas-indent-line 'fixed) (yas-wrap-around-region nil))
# --
-------------------------------------------------------------------------------
-- NAME    : ${1:function_name}
-- CREATED : `(capitalize (format-time-string "%d/%m/%Y"))`
-- AUTHOR  : `(and (boundp 'user-ngram) user-ngram)`
-------------------------------------------------------------------------------
-- ARGS  :
-- - $3
-------------------------------------------------------------------------------
-- RETURN  : ${4:True when all is OK, false in any other cases'}
-------------------------------------------------------------------------------
-- DESC : ${5:description}
-------------------------------------------------------------------------------
FUNCTION $1(${3:param})
RETURN   BOOLEAN IS
  v_result BOOLEAN := TRUE;
BEGIN
  trace('${2:package_name}',
        '$1 - start' || lf
     || '$3 => ' || $3);
  $0
  trace('$2', '$1 - End' || lf
     || 'v_result => ' || bool2var(v_result));
  return v_result;
END $1;
```
when expanded:

```sql
-------------------------------------------------------------------------------
-- NAME    : my function
-- CREATED : 22/07/2017
-- AUTHOR  : 
-------------------------------------------------------------------------------
-- ARGS  :
-- - param
-------------------------------------------------------------------------------
-- RETURN  : True when all is OK, false in any other cases'
-------------------------------------------------------------------------------
-- DESC : description
-------------------------------------------------------------------------------
FUNCTION my function(param)
RETURN   BOOLEAN IS
  v_result BOOLEAN := TRUE;
BEGIN
  trace('package_name',
  'my function - start' || lf
  || 'param => ' || param);
  
trace('package_name', 'my function - End' || lf
     || 'v_result => ' || bool2var(v_result));
  return v_result;
  END my function;
```

with the patch:

```sql
-------------------------------------------------------------------------------
-- NAME    : my function
-- CREATED : 22/07/2017
-- AUTHOR  : 
-------------------------------------------------------------------------------
-- ARGS  :
-- - param
-------------------------------------------------------------------------------
-- RETURN  : True when all is OK, false in any other cases'
-------------------------------------------------------------------------------
-- DESC : description
-------------------------------------------------------------------------------
FUNCTION my function(param)
RETURN   BOOLEAN IS
  v_result BOOLEAN := TRUE;
BEGIN
  trace('package_name',
        'my function - start' || lf
     || 'param => ' || param);
  
  trace('package_name', 'my function - End' || lf
     || 'v_result => ' || bool2var(v_result));
  return v_result;
END my function;
```



* yasnippet.el (yas--auto-fill): reinstate snippet environment before calling `yas--update-mirrors`.