### PR TITLE
Let snippet insertion delete field contents

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -589,6 +589,14 @@ mapconcat #'(lambda (arg)
       (yas-expand-snippet "Look ma! ${1:`(yas-selected-text)`} OK?")
       (should (string= (yas--buffer-contents) "Look ma! He)}o world! OK?")))))
 
+(ert-deftest insert-snippet-with-backslashes-in-active-field ()
+  ;; This test case fails if `yas--inhibit-overlay-hooks' is not bound
+  ;; in `yas-expand-snippet' (see Github #844).
+  (with-temp-buffer
+    (yas-minor-mode 1)
+    (yas-expand-snippet "${1:$$(if (not yas-modified-p) \"a\")}")
+    (yas-expand-snippet "\\\\alpha")))
+
 (ert-deftest example-for-issue-271 ()
   (with-temp-buffer
     (yas-minor-mode 1)

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3799,10 +3799,9 @@ considered when expanding the snippet."
              ;; them mostly to make the undo information
              ;;
              (setq yas--start-column (current-column))
-             (let ((yas--inhibit-overlay-hooks t))
-               (insert content)
-               (setq snippet
-                     (yas--snippet-create expand-env start (point)))))
+             (insert content)
+             (setq snippet
+                   (yas--snippet-create expand-env start (point))))
 
            ;; stacked-expansion: This checks for stacked expansion, save the
            ;; `yas--previous-active-field' and advance its boundary.


### PR DESCRIPTION
Fixes #844.

The overlay-hook inhibition seems to have existed since 0b55a52b8dc5b44b1db07876b38c032b92be7d4d, but it doesn't seem to be needed...

EDIT: [it's needed](https://github.com/joaotavora/yasnippet/issues/844#issuecomment-326866863)

```
* yasnippet.el (yas-expand-snippet): Don't bind
`yas--inhibit-overlay-hooks' when inserting the snippet.
```