### PR TITLE
Let whitespace-global-mode work in new snippet buffers

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -1019,13 +1019,13 @@ hello ${1:$(when (stringp yas-text) (funcall func yas-text))} foo${1:$$(concat \
         (yas-minor-mode +1)
         (save-current-buffer
           (yas-new-snippet t)
-          (with-current-buffer "*new snippet*"
+          (with-current-buffer yas-new-snippet-buffer-name
             (snippet-mode)
             (insert "# name: foo\n# key: bar\n# --\nsnippet foo")
             (call-interactively 'yas-load-snippet-buffer-and-close)))
         (save-current-buffer
           (yas-new-snippet t)
-          (with-current-buffer "*new snippet*"
+          (with-current-buffer yas-new-snippet-buffer-name
             (snippet-mode)
             (insert "# name: bar\n# key: bar\n# --\nsnippet bar")
             (call-interactively 'yas-load-snippet-buffer-and-close)))

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2528,6 +2528,10 @@ where snippets of table might exist."
               ;; create the .yas-parents file here...
               candidate)))))
 
+;; NOTE: Using the traditional "*new snippet*" stops whitespace mode
+;; from activating (it doesn't like the leading "*").
+(defconst yas-new-snippet-buffer-name "+new-snippet+")
+
 (defun yas-new-snippet (&optional no-template)
   "Pops a new buffer for writing a snippet.
 
@@ -2540,7 +2544,7 @@ NO-TEMPLATE is non-nil."
                                     (buffer-substring-no-properties
                                      (region-beginning) (region-end))))))
 
-    (switch-to-buffer "*new snippet*")
+    (switch-to-buffer yas-new-snippet-buffer-name)
     (erase-buffer)
     (kill-all-local-variables)
     (snippet-mode)


### PR DESCRIPTION
Fixes #842.
```
* yasnippet.el (yas-new-snippet-buffer-name): New constant, holds the
name of new snippet buffers.  Change it to "+new-snippet+" to avoid
the leading "*" from fooling whitespace-global-mode into thinking it
shouldn't activate.
(yas-new-snippet):
* yasnippet-tests.el (snippet-save): Use the constant instead of
hardcoding the literal string.
```