### PR TITLE
Release 0.12.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,9 +1,17 @@
 Yasnippet NEWS -- history of user-visible changes.
 
-Copyright (C) 2016 Free Software Foundation, Inc.
+Copyright (C) 2017 Free Software Foundation, Inc.
 See the end of the file for license conditions.
 
+* 0.12.2 (Aug 28, 2017)
 
+** The new option 'yas-also-auto-indent-empty-lines' allows restoring
+the old indent behavior.  See Github #850, #710, #685, #679.
+
+** Keybinding triggered snippets once again deactivate the mark.
+See Github #840.
+
+
 * 0.12.1 (Jul 23, 2017)
 
 This is a quick bugfix release.

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -5,7 +5,7 @@
 ;;          João Távora <joaotavora@gmail.com>,
 ;;          Noam Postavsky <npostavs@gmail.com>
 ;; Maintainer: Noam Postavsky <npostavs@gmail.com>
-;; Version: 0.12.1
+;; Version: 0.12.2
 ;; X-URL: http://github.com/joaotavora/yasnippet
 ;; Keywords: convenience, emulation
 ;; URL: http://github.com/joaotavora/yasnippet
@@ -540,7 +540,7 @@ override bindings from other packages (e.g., `company-mode')."
 
 ;;; Internal variables
 
-(defconst yas--version "0.12.1")
+(defconst yas--version "0.12.2")
 
 (defvar yas--menu-table (make-hash-table)
   "A hash table of MAJOR-MODE symbols to menu keymaps.")


### PR DESCRIPTION
This release just includes the fix for the regression in #840. Other outstanding fixes are too risky for a micro release, they will have to wait for 0.13.

```
* NEWS: Add changes for 0.12.2.
* yasnippet.el: Bump version.
* snippets: Update submodule.
```