### PR TITLE
Add yas-also-indent-empty-lines to allow old indent behavior

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -384,6 +384,23 @@ end" (buffer-string)))
 end" (buffer-string)))
     (should (= 4 (current-column)))))
 
+(ert-deftest yas-also-indent-empty-lines ()
+  "Respect `yas-also-indent-empty-lines' setting."
+  (with-temp-buffer
+    (ruby-mode)
+    (yas-minor-mode 1)
+    (set (make-local-variable 'yas-indent-line) 'auto)
+    (set (make-local-variable 'yas-also-auto-indent-first-line) t)
+    (set (make-local-variable 'yas-also-indent-empty-lines) t)
+    (yas-expand-snippet "def foo\n\nend")
+    (should (string= "def foo\n  \nend" (buffer-string)))
+    ;; Test that it keeps working without setting
+    ;; `yas-also-auto-indent-first-line'.
+    (setq yas-also-auto-indent-first-line nil)
+    (erase-buffer)
+    (yas-expand-snippet "def foo\n\nend")
+    (should (string= "def foo\n  \nend" (buffer-string)))))
+
 (ert-deftest indentation-markers ()
   "Test a snippet with indentation markers (`$<')."
   (with-temp-buffer

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -261,7 +261,11 @@ applies)."
 (defcustom yas-also-auto-indent-first-line nil
   "Non-nil means also auto indent first line according to mode.
 
-Naturally this is only valid when `yas-indent-line' is `auto'"
+Naturally this is only valid when `yas-indent-line' is `auto'."
+  :type 'boolean)
+
+(defcustom yas-also-indent-empty-lines nil
+  "Non-nil means also indent empty lines according to mode."
   :type 'boolean)
 
 (defcustom yas-snippet-revival t
@@ -4227,7 +4231,9 @@ The SNIPPET's markers are preserved."
         (goto-char from)
         (cl-loop for bol = (line-beginning-position)
                  for eol = (line-end-position)
-                 if (/= bol eol) do
+                 if (or yas-also-indent-empty-lines
+                        (/= bol eol))
+                 do
                  ;; Indent each non-empty line.
                  (let ((remarkers nil))
                    (dolist (m snippet-markers)


### PR DESCRIPTION
Fixes #850.
```
* yasnippet.el (yas-also-auto-indent-first-line): New option.
(yas--indent-region): Also indent empty lines if it's set.
* yasnippet-tests.el (yas-also-indent-empty-lines): New test.
```