### PR TITLE
Don't set yas-selected-text to non-selected text

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -625,6 +625,19 @@ mapconcat #'(lambda (arg)
     (yas-expand-snippet "${1:$$(if (not yas-modified-p) \"a\")}")
     (yas-expand-snippet "\\\\alpha")))
 
+(ert-deftest expand-with-unused-yas-selected-text ()
+  (with-temp-buffer
+    (yas-with-snippet-dirs
+      '((".emacs.d/snippets"
+         ("emacs-lisp-mode"
+          ("foo" . "expanded `yas-selected-text`foo"))))
+      (yas-reload-all)
+      (emacs-lisp-mode)
+      (yas-minor-mode +1)
+      (insert "foo")
+      (ert-simulate-command '(yas-expand))
+      (should (equal (buffer-string) "expanded foo")))))
+
 (ert-deftest example-for-issue-271 ()
   (with-temp-buffer
     (yas-minor-mode 1)

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3779,8 +3779,10 @@ considered when expanding the snippet."
          (to-delete (and (> end start)
                          (buffer-substring-no-properties start end)))
          (yas-selected-text
-          (or yas-selected-text
-              (if (not clear-field) to-delete)))
+          (cond (yas-selected-text)
+                ((and (region-active-p)
+                      (not clear-field))
+                 to-delete)))
          snippet)
     (goto-char start)
     (setq yas--indent-original-column (current-column))


### PR DESCRIPTION
Fixes #883.
```
* yasnippet.el (yas-expand-snippet): Only use the `to-delete' text if
`region-active-p' return true.
* yasnippet-tests.el (expand-with-unused-yas-selected-text): New test.
```