### PR TITLE
Add yasnippet-unload-function

### DIFF
--- a/yasnippet-debug.el
+++ b/yasnippet-debug.el
@@ -347,14 +347,6 @@ buffer-locally, otherwise install it globally.  If HOOK is
 (when command-line-args-left
   (yas-debug-process-command-line))
 
-(defun yas-exterminate-package ()
-  (interactive)
-  (yas-global-mode -1)
-  (yas-minor-mode -1)
-  (mapatoms #'(lambda (atom)
-                (when (string-match "yas[-/]" (symbol-name atom))
-                  (unintern atom obarray)))))
-
 (provide 'yasnippet-debug)
 ;; Local Variables:
 ;; indent-tabs-mode: nil

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4815,6 +4815,31 @@ and return the directory.  Return nil if not found."
                                          (directory-file-name file))))
                  (setq file nil))))
         root))))
+
+;;; Unloading
+
+(defvar unload-function-defs-list) ; loadhist.el
+
+(defun yasnippet-unload-function ()
+  "Disable minor modes when calling `unload-feature'."
+  ;; Disable `yas-minor-mode' everywhere it's enabled.
+  (yas-global-mode -1)
+  (save-current-buffer
+    (dolist (buffer (buffer-list))
+      (set-buffer buffer)
+      (when yas-minor-mode
+        (yas-minor-mode -1))))
+  ;; Remove symbol properties of all our functions, this avoids
+  ;; Bug#25088 in Emacs 25.1, where the compiler macro on
+  ;; `cl-defstruct' created functions hang around in the symbol plist
+  ;; and cause errors when loading again (we don't *need* to clean
+  ;; *all* symbol plists, but it's easier than being precise).
+  (dolist (def unload-function-defs-list)
+    (when (eq (car-safe def) 'defun)
+      (setplist (cdr def) nil)))
+  ;; Return nil so that `unload-feature' will take of undefining
+  ;; functions, and changing any buffers using `snippet-mode'.
+  nil)
 
 
 ;;; Backward compatibility to yasnippet <= 0.7


### PR DESCRIPTION
Resolves #753.
```
* yasnippet.el (yasnippet-unload-function): New function.
* yasnippet-debug.el (yas-exterminate-package): Remove, it was only
doing a partial job of undoing modes, and uninterning is entirely not
needed.
```