### PR TITLE
Bind field skip and clear command conditionally

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -274,7 +274,7 @@ attention to case differences."
     (ert-simulate-command '(yas-next-field-or-maybe-expand))
     (should (looking-at "testblable"))
     (ert-simulate-command '(yas-next-field-or-maybe-expand))
-    (ert-simulate-command '(yas-skip-and-clear-or-delete-char))
+    (ert-simulate-command '(yas-skip-and-clear-field))
     (should (looking-at "ble"))
     (should (null (yas-active-snippets)))))
 


### PR DESCRIPTION
Resolves #408.

```
Rather than embedding the conditionality inside the function body, and
hardcoding fallback to `delete-char'.  This allows users who want, for
example, to use backspace for field skipping to simply do

    (define-key yas-minor-mode-map (kbd "DEL")
      yas-maybe-skip-and-clear-field)

* yasnippet.el (yas-skip-and-clear-field, yas-current-field)
(yas--maybe-clear-field-filter): New command and function, extracted
from yas-skip-and-clear-or-delete-char.
(yas-skip-and-clear-or-delete-char): Mark obsolete.
(yas-maybe-skip-and-clear-field): New constant, for conditional
binding.
(yas-keymap): Bind it to `C-d' instead of
`yas-skip-and-clear-or-delete-char'.
* yasnippet-tests.el (delete-numberless-inner-snippet-issue-562): Use
`yas-skip-and-clear-field' instead of
`yas-skip-and-clear-or-delete-char'.
```