### PR TITLE
Update `yas--take-care-of-redo' call in buffer undo list

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3869,7 +3869,7 @@ After revival, push the `yas--take-care-of-redo' in the
   (when (yas--maybe-move-to-active-field snippet)
     (setf (yas--snippet-control-overlay snippet) (yas--make-control-overlay snippet beg end))
     (overlay-put (yas--snippet-control-overlay snippet) 'yas--snippet snippet)
-    (push `(apply yas--take-care-of-redo ,beg ,end ,snippet)
+    (push `(apply yas--take-care-of-redo ,snippet)
           buffer-undo-list)))
 
 (defun yas--snippet-create (content expand-env begin end)


### PR DESCRIPTION
Problem reported at https://emacs.stackexchange.com/questions/38242/problem-redoing-with-yasnippet.

```
On 2018-01-01 "Fix undo when first line indentation moves snippet
forward", `yas--take-care-of-redo' removed the BEG and END arguments,
but the call added to `buffer-undo-list' from `yas--snippet-revive',
was not updated accordingly.

* yasnippet.el (yas--snippet-revive): Remove `beg' and `end' from
`yas--take-care-of-redo' entry.
* yasnippet-tests.el (undo-redo): New test.
```