### PR TITLE
Fix expansion of commands snippet

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -673,6 +673,22 @@ mapconcat #'(lambda (arg)
       (ert-simulate-command '(yas-expand))
       (should (equal (buffer-string) "expanded foo")))))
 
+(ert-deftest yas-expand-command-snippet ()
+  (with-temp-buffer
+    (yas-with-snippet-dirs
+      '((".emacs.d/snippets"
+         ("emacs-lisp-mode"
+          ("foo" . "\
+# type: command
+# --
+\(insert \"expanded foo\")"))))
+      (yas-reload-all)
+      (emacs-lisp-mode)
+      (yas-minor-mode +1)
+      (insert "foo")
+      (ert-simulate-command '(yas-expand))
+      (should (equal (buffer-string) "expanded foo")))))
+
 (ert-deftest example-for-issue-271 ()
   (with-temp-buffer
     (yas-minor-mode 1)

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3791,8 +3791,8 @@ bindings considered when expanding the snippet.  If omitted, use
 SNIPPET's expand-env field.
 
 SNIPPET may be a snippet structure (e.g., as returned by
-`yas-lookup-snippet'), or just a string representing a snippet's
-body text."
+`yas-lookup-snippet'), or just a snippet body (which is a string
+for normal snippets, and a list for command snippets)."
   (cl-assert (and yas-minor-mode
                   (memq 'yas--post-command-handler post-command-hook))
              nil
@@ -3831,8 +3831,9 @@ body text."
     (when to-delete
       (delete-region start end))
 
-    (let ((content (if (stringp snippet) snippet
-                     (yas--template-content snippet))))
+    (let ((content (if (yas--template-p snippet)
+                       (yas--template-content snippet)
+                     snippet)))
       (when (and (not expand-env) (yas--template-p snippet))
         (setq expand-env (yas--template-expand-env snippet)))
       (cond ((listp content)


### PR DESCRIPTION
Fixes #899.

```
The previous changed failed to account for command snippets which have
lists for bodies, not strings.
* yasnippet.el (yas-expand-snippet): Don't error if SNIPPET is a list
representing a command snippet body.
* yasnippet-tests.el (yas-expand-command-snippet): New test.
```