### PR TITLE
Make yas-snippet-mode-buffer-p robust against symlinks

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -984,11 +984,8 @@ Honour `yas-dont-activate-functions', which see."
 Meaning it's visiting a file under one of the mode directories in
 `yas-snippet-dirs'."
   (when buffer-file-name
-    (member
-     (expand-file-name
-      ".."
-      (file-name-directory buffer-file-name))
-     (yas-snippet-dirs))))
+    (cl-member buffer-file-name (yas-snippet-dirs)
+               :test #'file-in-directory-p)))
 
 ;; We're abusing `magic-fallback-mode-alist' here because
 ;; `auto-mode-alist' doesn't support function matchers.


### PR DESCRIPTION
Fixes #901.

```
* yasnippet.el (yas-snippet-mode-buffer-p): Instead of a string
comparison of file names to check whether the buffer file is in on of
the `yas-snippet-dirs', use the builtin file-in-directory-p function.
```