### PR TITLE
Use fancy field adjustment for fixed indent too

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4303,9 +4303,13 @@ The SNIPPET's markers are preserved."
   ;; Now do stuff for `fixed' and `auto'.
   (save-excursion
     (cond ((eq yas-indent-line 'fixed)
-           (while (and (zerop (forward-line))
-                       (zerop (current-column)))
-             (indent-to-column yas--indent-original-column)))
+           (forward-line 1)
+           (let ((indent-line-function
+                  (lambda ()
+                    (indent-to-column yas--indent-original-column))))
+             (yas--indent-region (line-beginning-position)
+                                 (point-max)
+                                 snippet)))
           ((eq yas-indent-line 'auto)
            (unless yas-also-auto-indent-first-line
              (forward-line 1))


### PR DESCRIPTION
Fix #906.

```
* yasnippet.el (yas--indent): When `yas-indent-line' is `fixed',
instead of calling `indent-to-column' on each line directly, bind
`indent-line-function' and use `yas--indent-region'.  The latter uses
some clever tricks to keep field regions from extending into the newly
created whitespace.
```
