### PR TITLE
Don't indent first and only line of expanded snippet

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -447,6 +447,30 @@ end" (buffer-string)))
     (yas-expand-snippet "def foo\n\nend")
     (should (string= "def foo\n  \nend" (buffer-string)))))
 
+(ert-deftest yas-indent-first-line ()
+  (with-temp-buffer
+    (ruby-mode)
+    (yas-minor-mode 1)
+    (set (make-local-variable 'yas-indent-line) 'auto)
+    (set (make-local-variable 'yas-also-auto-indent-first-line) nil)
+    (set (make-local-variable 'yas-also-indent-empty-lines) nil)
+    (yas-expand-snippet "def foo\n$0\nend\n")
+    ;; First (and only) line should not indent.
+    (yas-expand-snippet "#not indented")
+    (should (equal "def foo\n#not indented\nend\n" (buffer-string)))))
+
+(ert-deftest yas-indent-first-line-fixed ()
+  (with-temp-buffer
+    (ruby-mode)
+    (yas-minor-mode 1)
+    (set (make-local-variable 'yas-indent-line) 'fixed)
+    (set (make-local-variable 'yas-also-auto-indent-first-line) nil)
+    (set (make-local-variable 'yas-also-indent-empty-lines) nil)
+    (yas-expand-snippet "    def foo\n    $0\n    end\n")
+    ;; First (and only) line should not indent.
+    (yas-expand-snippet "#not more indented")
+    (should (equal "    def foo\n    #not more indented\n    end\n" (buffer-string)))))
+
 (ert-deftest indentation-markers ()
   "Test a snippet with indentation markers (`$<')."
   (with-temp-buffer

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4302,23 +4302,26 @@ The SNIPPET's markers are preserved."
     (setq yas--indent-markers nil))
   ;; Now do stuff for `fixed' and `auto'.
   (save-excursion
+    ;; We need to be at end of line, so that `forward-line' will only
+    ;; report 0 if it actually moves over a newline.
+    (end-of-line)
     (cond ((eq yas-indent-line 'fixed)
-           (forward-line 1)
-           (let ((indent-line-function
-                  (lambda ()
-                    ;; We need to be at beginning of line in order to
-                    ;; indent existing whitespace correctly.
-                    (beginning-of-line)
-                    (indent-to-column yas--indent-original-column))))
+           (when (= (forward-line 1) 0)
+             (let ((indent-line-function
+                    (lambda ()
+                      ;; We need to be at beginning of line in order to
+                      ;; indent existing whitespace correctly.
+                      (beginning-of-line)
+                      (indent-to-column yas--indent-original-column))))
+               (yas--indent-region (line-beginning-position)
+                                   (point-max)
+                                   snippet))))
+          ((eq yas-indent-line 'auto)
+           (when (or yas-also-auto-indent-first-line
+                     (= (forward-line 1) 0))
              (yas--indent-region (line-beginning-position)
                                  (point-max)
-                                 snippet)))
-          ((eq yas-indent-line 'auto)
-           (unless yas-also-auto-indent-first-line
-             (forward-line 1))
-           (yas--indent-region (line-beginning-position)
-                               (point-max)
-                               snippet)))))
+                                 snippet))))))
 
 (defun yas--collect-snippet-markers (snippet)
   "Make a list of all the markers used by SNIPPET."


### PR DESCRIPTION
Fixes #912.
```
Unless yas-also-auto-indent-first-line applies.
* yasnippet.el (yas--indent): Check that forward-line successfully
moved 1 line forward before trying to indent.
* yasnippet-tests.el (yas-indent-first-line)
(yas-indent-first-line-fixed): New tests.
```