### PR TITLE
Close #937: Officially support automatically moving to next field

### DIFF
--- a/doc/snippet-development.org
+++ b/doc/snippet-development.org
@@ -420,8 +420,19 @@ The [[sym:yas-choose-value][=yas-choose-value=]] does this work for you. For exa
   </div>
 #+END_SRC
 
-See the definition of [[sym:yas-choose-value][=yas-choose-value=]] to see how it was written using
-the two variables.
+See the definition of [[sym:yas-choose-value][=yas-choose-value=]] to see how it was written
+using the two variables. If you're really lazy :) and can't spare a
+tab keypress, you can automatically move to the next field (or exit)
+after choosing the value with [[sym:yas-auto-next][=yas-auto-next=]]. The snippet above
+becomes:
+
+#+BEGIN_SRC snippet
+  <div align="${2:$$(yas-auto-next
+                      (yas-choose-value
+                        '("right" "center" "left")))}">
+    $0
+  </div>
+#+END_SRC
 
 Here's another use, for LaTeX-mode, which calls reftex-label just as you
 enter snippet field 2. This one makes use of [[sym:yas-modified-p][=yas-modified-p=]] directly.

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2987,6 +2987,18 @@ The last element of POSSIBILITIES may be a list of strings."
                (funcall fn "Choose: " possibilities))
              yas-prompt-functions)))
 
+(defun yas--auto-next ()
+  "Helper for `yas-auto-next'."
+  (remove-hook 'post-command-hook #'yas--auto-next t)
+  (yas-next-field))
+
+(defmacro yas-auto-next (&rest body)
+  "Automatically advance to next field after eval'ing BODY."
+  (declare (indent 0) (debug t))
+  `(unless yas-moving-away-p
+     (prog1 ,@body
+       (add-hook 'post-command-hook #'yas--auto-next nil t))))
+
 (defun yas-key-to-value (alist)
   (unless (or yas-moving-away-p
               yas-modified-p)


### PR DESCRIPTION
* yasnippet-tests.el (auto-next-field): New test.
(yas-saving-variables): Move up in the file.

* yasnippet.el (yas--auto-next): New helper.
(yas-auto-next): New user-visible snippet helper.

* doc/snippet-development.org (Choosing fields value from a list
and other tricks): Add mention of yas-auto-next.