### PR TITLE
Consider fundamental-mode as ultimate ancestor

### DIFF
--- a/doc/snippet-expansion.org
+++ b/doc/snippet-expansion.org
@@ -161,11 +161,13 @@ In particular, the following things matter:
    =M-x describe-variable RET major-mode RET= to find out which major
    mode you are in currently.
 
--  Parent tables
+- Parent tables
 
-   Snippet tables defined as the parent of some other eligible table are
-   also considered. This works recursively, i.e. parents of parents of
-   eligible tables are also considered.
+  Snippet tables defined as the parent of some other eligible table
+  are also considered.  This works recursively, i.e., parents of
+  parents of eligible tables are also considered.  As a special case,
+  if a mode doesn't have a parent, then =fundamental-mode= is
+  considered to be its parent.
 
 -  Buffer-local list of extra modes
 

--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -1260,7 +1260,8 @@ hello ${1:$(when (stringp yas-text) (funcall func yas-text))} foo${1:$$(concat \
      (yas-reload-all)
      (with-temp-buffer
        (let* ((major-mode 'c-mode)
-              (expected `(c-mode
+              (expected `(fundamental-mode
+                          c-mode
                           cc-mode
                           yet-another-c-mode
                           and-also-this-one
@@ -1313,7 +1314,8 @@ hello ${1:$(when (stringp yas-text) (funcall func yas-text))} foo${1:$$(concat \
                          (yas-reload-all)
                          (with-temp-buffer
                            (let* ((major-mode 'yas--test-mode)
-                                  (expected `(c-mode
+                                  (expected `(fundamental-mode
+                                              c-mode
                                               ,@(if (fboundp 'prog-mode)
                                                     '(prog-mode))
                                               yas--phony-c-mode

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -801,7 +801,10 @@ which decides on the snippet to expand.")
          (yas--dfs
           (lambda (mode)
             (cl-loop for neighbour
-                     in (cl-list* (get mode 'derived-mode-parent)
+                     in (cl-list* (or (get mode 'derived-mode-parent)
+                                      ;; Consider `fundamental-mode'
+                                      ;; as ultimate ancestor.
+                                      'fundamental-mode)
                                   ;; NOTE: `fboundp' check is redundant
                                   ;; since Emacs 24.4.
                                   (and (fboundp mode) (symbol-function mode))


### PR DESCRIPTION
See https://github.com/joaotavora/yasnippet/issues/936#issuecomment-388187042 and followups.
```
* yasnippet.el (yas--modes-to-activate): If a mode doesn't have a
`derived-mode-parent' property, use `fundamental-mode'.
* yasnippet-tests.el (loading-with-cyclic-parenthood)
(issue-492-and-494): Expect fundamental-mode to be active.
* doc/snippet-expansion.org (Eligible snippets): Mention that
fundamental-mode is a fallback parent mode.
```