### PR TITLE
Add yas-completing-read

### DIFF
--- a/doc/snippet-development.org
+++ b/doc/snippet-development.org
@@ -412,15 +412,17 @@ the field, and with some useful variables bound, notably
 can place a transformation in the primary field that lets you select
 default values for it.
 
-The [[sym:yas-choose-value][=yas-choose-value=]] does this work for you. For example:
+For example, the [[sym:yas-choose-value][=yas-completing-read=]] function is version of
+=completing-read= which checks these variables.  For example, asking
+the user for the initial value of a field:
 
 #+BEGIN_SRC snippet
-  <div align="${2:$$(yas-choose-value '("right" "center" "left"))}">
+  <div align="${2:$$(yas-completing-read "Alignment? " '("right" "center" "left"))}">
     $0
   </div>
 #+END_SRC
 
-See the definition of [[sym:yas-choose-value][=yas-choose-value=]] to see how it was written
+See the definition of [[sym:yas-choose-value][=yas-completing-read=]] to see how it was written
 using the two variables. If you're really lazy :) and can't spare a
 tab keypress, you can automatically move to the next field (or exit)
 after choosing the value with [[sym:yas-auto-next][=yas-auto-next=]]. The snippet above
@@ -428,7 +430,8 @@ becomes:
 
 #+BEGIN_SRC snippet
   <div align="${2:$$(yas-auto-next
-                      (yas-choose-value
+                      (yas-completing-read
+                        "Alignment? "
                         '("right" "center" "left")))}">
     $0
   </div>
@@ -440,8 +443,7 @@ enter snippet field 2. This one makes use of [[sym:yas-modified-p][=yas-modified
 #+BEGIN_SRC snippet
   \section{${1:"Titel der Tour"}}%
   \index{$1}%
-  \label{{2:"waiting for reftex-label call..."$(unless yas-modified-p (reftex-label nil 'dont-
-  insert))}}%
+  \label{{2:"waiting for reftex-label call..."$(unless yas-modified-p (reftex-label nil 'dont-insert))}}%
 #+END_SRC
 
 The function [[sym:yas-verify-value][=yas-verify-value=]] has another neat trick, and makes use

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2987,6 +2987,16 @@ The last element of POSSIBILITIES may be a list of strings."
                (funcall fn "Choose: " possibilities))
              yas-prompt-functions)))
 
+(defun yas-completing-read (&rest args)
+  "A snippet-aware version of `completing-read'.
+This can be used to query the user for the initial value of a
+snippet field.  The arguments are the same as `completing-read'.
+
+\(fn PROMPT COLLECTION &optional PREDICATE REQUIRE-MATCH INITIAL-INPUT HIST DEF INHERIT-INPUT-METHOD)"
+  (unless (or yas-moving-away-p
+              yas-modified-p)
+    (apply #'completing-read args)))
+
 (defun yas--auto-next ()
   "Helper for `yas-auto-next'."
   (remove-hook 'post-command-hook #'yas--auto-next t)
@@ -3016,7 +3026,7 @@ The last element of POSSIBILITIES may be a list of strings."
 (defun yas-verify-value (possibilities)
   "Verify that the current field value is in POSSIBILITIES.
 Otherwise signal `yas-exception'."
-  (when (and yas-moving-away-p (cl-notany (lambda (pos) (string= pos yas-text)) possibilities))
+  (when (and yas-moving-away-p (not (member yas-text possibilities)))
     (yas-throw (format "Field only allows %s" possibilities))))
 
 (defun yas-field-value (number)


### PR DESCRIPTION
Close #934.
```
* yasnippet.el (yas-completing-read): New function.
(yas-verify-value): Simplify with `member' instead of `cl-notany'.
* doc/snippet-development.org (Template Syntax): Show
`yas-completing-read' instead of `yas-choose-value' in the example.
```