### PR TITLE
Handle field adjust of pending active fields

### DIFF
--- a/yasnippet-debug.el
+++ b/yasnippet-debug.el
@@ -141,7 +141,9 @@
          (decorator-end (overlay-get ov 'after-string))
          (beg (yas-debug-ov-fom-start range))
          (end (yas-debug-ov-fom-end range)))
-    (if (and beg end (not (integerp beg)) (not (integerp end)))
+    (if (and beg end (or (overlayp range)
+                         (and (not (integerp beg))
+                              (not (integerp end)))))
         (propertize (format "from %d to %d" (+ beg) (+ end))
                     'cursor-sensor-functions
                     `(,(lambda (_window _oldpos dir)
@@ -155,7 +157,7 @@
       "<dead>")))
 
 (defmacro yas-debug-with-tracebuf (outbuf &rest body)
-  (declare (indent 1))
+  (declare (indent 1) (debug (sexp body)))
   (let ((tracebuf-var (make-symbol "tracebuf")))
     `(let ((,tracebuf-var (or ,outbuf (get-buffer-create "*YASnippet trace*"))))
        (unless (eq ,tracebuf-var (current-buffer))

--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -1066,6 +1066,26 @@ hello ${1:$(when (stringp yas-text) (funcall func yas-text))} foo${1:$$(concat \
       (ert-simulate-command '(yas-next-field-or-maybe-expand))
       (should (string= (buffer-string) "\\sqrt[3]{\\sqrt[5]{2}}")))))
 
+(ert-deftest nested-snippet-expansion-4 ()
+  "See Github #959."
+  (let ((yas-triggers-in-field t))
+    (yas-with-snippet-dirs
+     '((".emacs.d/snippets"
+        ("text-mode"
+         ("ch" . "<-${1:ch}"))))
+     (yas-reload-all)
+     (text-mode)
+     (yas-minor-mode +1)
+     (yas-expand-snippet "ch$0\n")
+     (ert-simulate-command '(yas-expand))
+     (ert-simulate-command '(forward-char 2))
+     (ert-simulate-command '(yas-expand))
+     (yas-mock-insert "abc")
+     (ert-simulate-command '(yas-next-field-or-maybe-expand))
+     (yas-mock-insert "def")
+     (ert-simulate-command '(yas-next-field-or-maybe-expand))
+     (should (string= (buffer-string) "<-<-abcdef\n")))))
+
 
 ;;; Loading
 ;;;


### PR DESCRIPTION
Fix #959 (?)
```
* yasnippet.el (yas--on-field-overlay-modification): Call
yas--advance-end-maybe on all pending active snippets in case of
stacked expansion.
```