### PR TITLE
Fix another failure of cc-mode indentation

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -556,6 +556,22 @@ int foo()
   }
 }" (buffer-string)))))
 
+(ert-deftest indent-cc-mode-2 ()
+  "Handling of cc-mode's preprocessor indentation."
+  (with-temp-buffer
+    (c-mode)
+    (yas-minor-mode +1)
+    (yas-expand-snippet "\
+#ifndef `\"FOO\"`
+#define FOO
+#endif
+")
+    (should (string= "\
+#ifndef FOO
+#define FOO
+#endif
+" (buffer-substring-no-properties (point-min) (point-max))))))
+
 (ert-deftest indent-snippet-mode ()
   "Handling of snippet-mode indentation."
   ;; This is an interesting case because newlines match [[:space:]] in

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4035,13 +4035,18 @@ Returns the newly created snippet."
         ;; content.
         (let ((buffer-undo-list t))
           ;; Some versions of cc-mode fail when inserting snippet
-          ;; content in a narrowed buffer.
+          ;; content in a narrowed buffer, so make sure to insert
+          ;; before narrowing.  Furthermore, call before and after
+          ;; change functions, otherwise cc-mode's cache can get
+          ;; messed up.
           (goto-char begin)
+          (run-hook-with-args 'before-change-functions begin begin)
           (insert content)
           (setq end (+ end (length content)))
           (narrow-to-region begin end)
           (goto-char (point-min))
-          (yas--snippet-parse-create snippet))
+          (yas--snippet-parse-create snippet)
+          (run-hook-with-args 'after-change-functions (point-min) (point-max) 0))
         (when (listp buffer-undo-list)
           (push (cons (point-min) (point-max))
                 buffer-undo-list))


### PR DESCRIPTION
Fixes #953.
```
Suggested by OGAWA Hirofumi in
https://github.com/joaotavora/yasnippet/issues/953.
* yasnippet.el (yas--snippet-create): Call before and after change
functions around yas--snippet-parse-create.
* yasnippet-tests.el (indent-cc-mode-2): New test.
```