### PR TITLE
Don't call before/after change-functions twice

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4076,12 +4076,13 @@ Returns the newly created snippet."
       (yas--letenv expand-env
         ;; Put a single undo action for the expanded snippet's
         ;; content.
-        (let ((buffer-undo-list t))
+        (let ((buffer-undo-list t)
+              (inhibit-modification-hooks t))
           ;; Some versions of cc-mode fail when inserting snippet
           ;; content in a narrowed buffer, so make sure to insert
           ;; before narrowing.  Furthermore, call before and after
-          ;; change functions, otherwise cc-mode's cache can get
-          ;; messed up.
+          ;; change functions manually, otherwise cc-mode's cache can
+          ;; get messed up.
           (goto-char begin)
           (run-hook-with-args 'before-change-functions begin begin)
           (insert content)


### PR DESCRIPTION
Might fix #964.
```
* yasnippet.el (yas--snippet-create): Let-bind
inhibit-modification-hooks for snippet insertion, so that we don't
call change functions automatically, we already call them manually
after insertion and parsing.
```