### PR TITLE
Fix condition checking in key filter

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -637,7 +637,8 @@ override bindings from other packages (e.g., `company-mode')."
   "Return CMD if there is an expandable snippet at point.
 This function is useful as a `:filter' to a conditional key
 definition."
-  (when (let ((yas--condition-cache-timestamp (current-time)))
+  (when (let ((yas--condition-cache-timestamp (current-time))
+              (this-command 'yas-expand))
           (yas--templates-for-key-at-point))
     cmd))
 


### PR DESCRIPTION
Fixes #973, though I'm not entirely sure it's the Right Thing.
```
* yasnippet.el (yas-maybe-expand-abbrev-key-filter): Let-bind
`this-command' to `yas-expand', some snippet conditions may rely on
this (e.g., `yas-not-string-or-comment-condition').
```