### PR TITLE
Fix snippet undo

### DIFF
--- a/yasnippet-debug.el
+++ b/yasnippet-debug.el
@@ -254,6 +254,8 @@ buffer-locally, otherwise install it globally.  If HOOK is
             (setq yas-debug-target-snippets
                   (cl-delete-if-not #'yas--snippet-p yas-debug-target-snippets)))
           (let ((yas-debug-recently-live-indicators nil))
+            (printf "(length yas--snippets-snippets) => %d\n"
+                    (length yas--active-snippets))
             (dolist (snippet (or yas-debug-target-snippets
                                  (yas-active-snippets)))
               (printf "snippet %d\n" (yas--snippet-id snippet))

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4149,6 +4149,7 @@ After revival, push the `yas--take-care-of-redo' in the
   (when (yas--maybe-move-to-active-field snippet)
     (setf (yas--snippet-control-overlay snippet) (yas--make-control-overlay snippet beg end))
     (overlay-put (yas--snippet-control-overlay snippet) 'yas--snippet snippet)
+    (push snippet yas--active-snippets)
     (when (listp buffer-undo-list)
       (push `(apply yas--take-care-of-redo ,snippet)
             buffer-undo-list))))


### PR DESCRIPTION
Fixes #1006.

```
* yasnippet.el (yas--snippet-revive): Add revived snippet to
yas--active-snippets.
* yasnippet-debug.el (yas-debug-snippets): Print yas--active-snippets
length.
```