### PR TITLE
Handle multiple uses of yas-auto-next

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -694,7 +694,11 @@ mapconcat #'(lambda (arg)
                                          (prin1-to-string '(yas-auto-next
                                                             (yas-choose-value
                                                              "bar" "foo")))
-                                         "} baz ${2:quinn} quinn")))))
+                                         "} ${2:$$"
+                                         (prin1-to-string '(yas-auto-next
+                                                            (yas-choose-value
+                                                             "too" "foo")))
+                                         "} baz ${3:quinn} quinn")))))
       (yas-reload-all)
       (ruby-mode)
       (yas-minor-mode 1)
@@ -702,7 +706,7 @@ mapconcat #'(lambda (arg)
       (yas-mock-insert "snip")
       (ert-simulate-command '(yas-expand))
       (yas-mock-insert "quux")
-      (should (equal "foo bar baz quux quinn" (buffer-string)))))))
+      (should (equal "foo bar too baz quux quinn" (buffer-string)))))))
 
 
 ;;; Snippet expansion and character escaping

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3039,8 +3039,13 @@ snippet field.  The arguments are the same as `completing-read'.
 
 (defun yas--auto-next ()
   "Helper for `yas-auto-next'."
-  (remove-hook 'post-command-hook #'yas--auto-next t)
-  (yas-next-field))
+  (cl-loop
+   do (progn (remove-hook 'post-command-hook #'yas--auto-next t)
+             (yas-next-field))
+   ;; The transform in the next field may have requested auto-next as
+   ;; well.  Call it ourselves, since the command loop itself won't
+   ;; recheck the value of post-command-hook while running it.
+   while (memq #'yas--auto-next post-command-hook)))
 
 (defmacro yas-auto-next (&rest body)
   "Automatically advance to next field after eval'ing BODY."


### PR DESCRIPTION
Fixes #1010.

```
* yasnippet.el (yas--auto-next): Loop again after moving to the next
field.
```