### PR TITLE
Fix can't insert a new snippet.

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1399,6 +1399,9 @@ conditions to filter out potential expansions."
                                 (push (cons name template) acc))
                             namehash))
                (yas--table-hash table))
+      (maphash #'(lambda (uuid template)
+                   (push (cons uuid template) acc))
+               (yas--table-uuidhash table))
       (yas--filter-templates-by-condition acc))))
 
 (defun yas--templates-for-key-at-point ()


### PR DESCRIPTION
When I use yas-new-snippet to create a new snippet, when the scrippet is
with a complex name (such as "test.snippet"), after I save the snippet,
I can't use yas-insert-snippet to insert it. I do can see it in the menu
bar, though.

This patch fixes this problem.