### PR TITLE
Fix failure on depth 2+ nested snippets

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -1099,6 +1099,24 @@ hello ${1:$(when (stringp yas-text) (funcall func yas-text))} foo${1:$$(concat \
         (should (= (length (yas--snippet-fields (nth 0 snippets))) 2))
         (should (= (length (yas--snippet-fields (nth 1 snippets))) 1))))))
 
+(ert-deftest nested-snippet-expansion-depth-2 ()
+  (with-temp-buffer
+    (yas-with-snippet-dirs
+      '((".emacs.d/snippets"
+         ("text-mode"
+          ("nest" . "( $1"))))
+      (let ((yas-triggers-in-field t))
+        (yas-reload-all)
+        (text-mode)
+        (yas-minor-mode +1)
+        (dotimes (_ 3)
+          (yas-mock-insert "nest")
+          (ert-simulate-command '(yas-expand)))
+        (dotimes (_ 3)
+          (yas-mock-insert ")")
+          (ert-simulate-command '(yas-next-field-or-maybe-expand)))
+        ))))
+
 (ert-deftest nested-snippet-expansion-2 ()
   (let ((yas-triggers-in-field t))
     (yas-with-snippet-dirs


### PR DESCRIPTION
Fixes #1038

```
* yasnippet.el (yas--advance-end-maybe-previous-fields): New function.
(yas--commit-snippet, yas--on-field-overlay-modification)
(yas-expand-snippet): Use it, so that all active fields will be
extended properly, even in case of deeply nested snippet expansion.
* yasnippet-tests.el (nested-snippet-expansion-depth-2): New test.
```