### PR TITLE
Scan nested fields properly

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -947,6 +947,18 @@ mapconcat #'(lambda (arg)
       (yas-mock-insert "baz")
       (should (string= (yas--buffer-contents) "foobaaarbazok")))))
 
+(ert-deftest yas-escaping-close-brace ()
+  "Close braces may be escaped with braces, reduction from eglot issue.
+See https://github.com/joaotavora/eglot/issues/336."
+  (with-temp-buffer
+    (yas-minor-mode +1)
+    ;; NOTE: put a period at the end to avoid the bug tested by
+    ;; `protection-overlay-no-cheating'.
+    (yas-expand-snippet "${1:one{\\}}, ${2:two{\\}}.")
+    (yas-next-field)
+    (yas-next-field)
+    (should (string= (buffer-string) "one{}, two{}."))))
+
 
 ;;; Misc tests
 ;;;


### PR DESCRIPTION
Fixes joaotavora/eglot#336.  I think the other calls to
`yas--scan-sexps` may need to be replaced as well.

```
* yasnippet.el (yas--scan-for-field-end): New function.
(yas--field-parse-create): Use it instead of yas--scan-sexps, which
isn't able to distinguish between ${...} (a nested field) and
{...} (plain old braces in the snippet text).
* yasnippet-tests.el (yas-escaping-close-brace): New test.
```