### PR TITLE
Don't bind inhibit-modification-hooks in yas--snippet-create

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4168,21 +4168,26 @@ Returns the newly created snippet."
       (yas--letenv expand-env
         ;; Put a single undo action for the expanded snippet's
         ;; content.
-        (let ((buffer-undo-list t)
-              (inhibit-modification-hooks t))
-          ;; Some versions of cc-mode fail when inserting snippet
-          ;; content in a narrowed buffer, so make sure to insert
-          ;; before narrowing.  Furthermore, call before and after
-          ;; change functions manually, otherwise cc-mode's cache can
-          ;; get messed up.
+        (let ((buffer-undo-list t))
           (goto-char begin)
-          (run-hook-with-args 'before-change-functions begin begin)
-          (insert content)
-          (setq end (+ end (length content)))
-          (narrow-to-region begin end)
-          (goto-char (point-min))
-          (yas--snippet-parse-create snippet)
-          (run-hook-with-args 'after-change-functions (point-min) (point-max) 0))
+          ;; Call before and after change functions manually,
+          ;; otherwise cc-mode's cache can get messed up.  Don't use
+          ;; `inhibit-modification-hooks' for that, that blocks
+          ;; overlay and text property hooks as well!  FIXME: Maybe
+          ;; use `combine-change-calls'?  (Requires Emacs 27+ though.)
+          (run-hook-with-args 'before-change-functions begin end)
+          (let ((before-change-functions nil)
+                (after-change-functions nil))
+            ;; Some versions of cc-mode fail when inserting snippet
+            ;; content in a narrowed buffer, so make sure to insert
+            ;; before narrowing.
+            (insert content)
+            (narrow-to-region begin (point))
+            (goto-char (point-min))
+            (yas--snippet-parse-create snippet))
+          (run-hook-with-args 'after-change-functions
+                              (point-min) (point-max)
+                              (- (point-max) (point-min))))
         (when (listp buffer-undo-list)
           (push (cons (point-min) (point-max))
                 buffer-undo-list))


### PR DESCRIPTION
Maybe fixes #1041.

```
* yasnippet.el (yas--snippet-create): Bind before-change-functions and
after-change-functions to nil instead of inhibit-modification-hooks to
t while expanding snippet.  The latter also needlessly blocks overlay
and text property modification hooks (which we don't call ourselves
afterwards).  This way we allow packages like iedit to better
co-operate with yasnippet.
```