### PR TITLE
Narrow scope of undo disabling

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4168,31 +4168,31 @@ Returns the newly created snippet."
       (yas--letenv expand-env
         ;; Put a single undo action for the expanded snippet's
         ;; content.
-        (let ((buffer-undo-list t))
-          (goto-char begin)
-          ;; Call before and after change functions manually,
-          ;; otherwise cc-mode's cache can get messed up.  Don't use
-          ;; `inhibit-modification-hooks' for that, that blocks
-          ;; overlay and text property hooks as well!  FIXME: Maybe
-          ;; use `combine-change-calls'?  (Requires Emacs 27+ though.)
-          (run-hook-with-args 'before-change-functions begin end)
-          (let ((before-change-functions nil)
-                (after-change-functions nil))
-            ;; Some versions of cc-mode (might be the one with Emacs
-            ;; 24.3 only) fail when inserting snippet content in a
-            ;; narrowed buffer, so make sure to insert before
-            ;; narrowing.
-            (insert content)
-            (narrow-to-region begin (point))
-            (goto-char (point-min))
-            (yas--snippet-parse-create snippet))
-          (run-hook-with-args 'after-change-functions
-                              (point-min) (point-max)
-                              (- end begin)))
+        (goto-char begin)
+        ;; Call before and after change functions manually,
+        ;; otherwise cc-mode's cache can get messed up.  Don't use
+        ;; `inhibit-modification-hooks' for that, that blocks
+        ;; overlay and text property hooks as well!  FIXME: Maybe
+        ;; use `combine-change-calls'?  (Requires Emacs 27+ though.)
+        (run-hook-with-args 'before-change-functions begin end)
+        (let ((buffer-undo-list t)
+              (before-change-functions nil)
+              (after-change-functions nil))
+          ;; Some versions of cc-mode (might be the one with Emacs
+          ;; 24.3 only) fail when inserting snippet content in a
+          ;; narrowed buffer, so make sure to insert before
+          ;; narrowing.
+          (insert content)
+          (narrow-to-region begin (point))
+          (goto-char (point-min))
+          (yas--snippet-parse-create snippet))
         (when (listp buffer-undo-list)
           (push (cons (point-min) (point-max))
                 buffer-undo-list))
 
+        (run-hook-with-args 'after-change-functions
+                            (point-min) (point-max)
+                            (- end begin))
         ;; Indent, collecting undo information normally.
         (yas--indent snippet)
 


### PR DESCRIPTION
Might fix additional problem reported in
https://github.com/joaotavora/yasnippet/issues/1041#issuecomment-619466606

```
* yasnippet.el (yas--snippet-create): Don't bind buffer-undo-list
around before and after change-functions.
```