### PR TITLE
Use lexical-binding in yasnippet.el

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1,4 +1,4 @@
-;;; yasnippet.el --- Yet another snippet extension for Emacs
+;;; yasnippet.el --- Yet another snippet extension for Emacs  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2008-2019 Free Software Foundation, Inc.
 ;; Authors: pluskid <pluskid@gmail.com>,


### PR DESCRIPTION
Emacs can optimize files that use lexical-binding slightly better, so this is a good thing to do. Additionally I've been experimenting with Andrea Corallo's `feature/native-comp` branch in upstream Emacs, and it can only native compile elisp files that use lexical-bidning, which is how I noticed that yasnippet.el did not.

The tests pass in this branch and I don't get any warnings when byte-compiling (or native compiling) the file with lexical-binding, so it seems like a safe change to make.

I agree to copyright assignment of this change as described in the contributing guidelines.