### PR TITLE
Handle errors during evaluation properly

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -847,7 +847,7 @@ mapconcat #'(lambda (arg)
   ;; See https://github.com/joaotavora/yasnippet/issues/800.
   (with-temp-buffer
     (yas-minor-mode 1)
-    (should-error (yas-expand-snippet "```foo\n\n```"))
+    (yas-expand-snippet "```foo\n\n```")
     (erase-buffer) ; Bad snippet may leave wrong text.
     ;; But expanding the corrected snippet should work fine.
     (yas-expand-snippet "\\`\\`\\`foo\n\n\\`\\`\\`")

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1505,7 +1505,7 @@ Also tries to work around Emacs Bug#30931."
               (let ((result (eval form)))
                 (when result
                   (format "%s" result))))))
-      ((debug error) (cdr oops)))))
+      ((debug error) (error-message-string oops)))))
 
 (defun yas--eval-for-effect (form)
   (yas--safely-call-fun (apply-partially #'eval form)))


### PR DESCRIPTION
Fixes problem that came up in #1055.

```
* yasnippet.el (yas--eval-for-string): Convert error to a string,
rather than returning the error data (which can only lead to confusing
type errors later when code expecting a string gets a list).
* yasnippet-tests.el (yas-no-memory-of-bad-snippet): Adjust test, now
that snippet expansion swallows errors properly.
```