### PR TITLE
yas-describe-tables: sort snippets by name (within each group)

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2934,7 +2934,7 @@ DEBUG is for debugging the YASnippet engine itself."
      #'(lambda (group templates)
          (setq group (truncate-string-to-width group 25 0 ?  "..."))
          (insert (make-string 100 ?-) "\n")
-         (dolist (p templates)
+         (dolist (p (cl-sort templates #'string< :key #'yas--template-name))
            (let* ((name (truncate-string-to-width (propertize (format "\\\\snippet `%s'" (yas--template-name p))
                                                               'yasnippet p)
                                                   50 0 ? "..."))


### PR DESCRIPTION
Trivial change. Useful when you use mnemonics for snippet `key`s to have a nice sorted overview.