### PR TITLE
Correct link to 'Eligible snippets' headline

### DIFF
--- a/doc/snippet-expansion.org
+++ b/doc/snippet-expansion.org
@@ -227,7 +227,7 @@ For the full set of possible conditions, see the documentation for
 
 ** Multiples snippet with the same key
 
-The rules outlined [[Eligible%20snippets][above]] can return more than
+The rules outlined [[Eligible snippets][above]] can return more than
 one snippet to be expanded at point.
 
 When there are multiple candidates, YASnippet will let you select one.


### PR DESCRIPTION
I've confirmed that this patch produces a functioning link using Emacs 27.1 which bundles org-mode 9.3.  Without it, generating HTML docs with `emacs -Q -L /usr/share/emacs/site-lisp/elpa-src/htmlize-* -L . --batch -l htmlize
 -l doc/yas-doc-helper.el -f yas--generate-html-batch` fails with
```
Code block evaluation complete.
Publishing file /<<PKGBUILDDIR>>/doc/snippet-expansion.org using ‘org-html-publish-to-html’
Unable to resolve link: "Eligible%20snippets"
```

Were I to guess, I'd guess that encoding the space was necessary in past org-mode releases.  This appears to no longer be necessary because a valid `<a href="#org5b8a14e">` link is generated now.