### PR TITLE
Prevent infinite recursion when displaying a warning.

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3919,6 +3919,12 @@ field start.  This hook does nothing if an undo is in progress."
                 (when (local-variable-p 'auto-fill-function)
                   (if af-cell (setcdr af-cell (cons buf (cdr af-cell)))
                     (push (list auto-fill-function buf) fill-fun-values))))))
+          ;; Prevent infinite recursion if printing the warning tries to
+          ;; auto-fill.
+          (let ((buffer (get-buffer "*Warnings*")))
+            (when (buffer-live-p buffer)
+              (with-current-buffer buffer
+                (auto-fill-mode -1))))
           (lwarn '(yasnippet auto-fill bug) :error
                  "`yas--original-auto-fill-function' unexpectedly nil in %S!  Disabling auto-fill.
   %S


### PR DESCRIPTION
If the *Warnings* buffer has auto-fill enabled and we're about to print the
warning, `display-warning' would loop back here through `newline' and
`self-insert-command', causing infinite recursion.

I haven't been able to reproduce this in a noninteractive unit test,
unfortunately, but the issue happens in interactive mode whenever
`yas--original-auto-fill-function' is nil and `auto-fill-mode' is enabled in
the *Warnings* buffer.

* yasnippet.el (yas--auto-fill): Disable `auto-fill-mode' in the *Warnings*
buffer as well.