### PR TITLE
Notes on recompiling snippets for the compile functions.

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2097,13 +2097,19 @@ prefix argument."
   "Create .yas-compiled-snippets.el files under subdirs of TOP-LEVEL-DIR.
 
 This works by stubbing a few functions, then calling
-`yas-load-directory'."
+`yas-load-directory'.
+
+Remember to recompile the directory after adding or updating snippets,
+or they will not be effective."
   (interactive "DTop level snippet directory?")
   (let ((yas--creating-compiled-snippets t))
     (yas-load-directory top-level-dir nil)))
 
 (defun yas-recompile-all ()
-  "Compile every dir in `yas-snippet-dirs'."
+  "Compile every dir in `yas-snippet-dirs'.
+
+Remember to recompile all after adding or updating snippets,
+or they will not be effective."
   (interactive)
   (mapc #'yas-compile-directory (yas-snippet-dirs)))
 


### PR DESCRIPTION
Here is the story:

I added a snippet other day and it worked, but it didn't work any more after I restarted Emacs.

I was struggling to try to find out the problem and then I found that there was a `.yas-compiled-snippets.el` file in the snippet directory. I tried to remove it and it worked perfectly.

So I am thinking that it's better to put a note on the docstring, so here it is.