### PR TITLE
Separate command key substitution and example block enclosing

### DIFF
--- a/doc/yas-doc-helper.el
+++ b/doc/yas-doc-helper.el
@@ -96,7 +96,7 @@
                 "\\\\{[^}]+}"
                 (lambda (match)
                   (concat "#+BEGIN_EXAMPLE\n"
-                          (substitute-command-keys match)
+                          match
                           "#+END_EXAMPLE\n"))
                 body t t)
           body (substitute-command-keys body)


### PR DESCRIPTION
The following form : 

```elisp
(replace-regexp-in-string "\\\\{[^}]+}"
			  (lambda (match)
			    (substitute-command-keys match))
			  "\\{yas-minor-mode-map}")
```

produces the following error in emacs 28+ : 

```
Debugger entered--Lisp error: (args-out-of-range 21 22)
  replace-regexp-in-string("\\\\{[^}]+}" (closure (t) (match) (substitute-command-keys match)) "\\{yas-minor-mode-map}")
  (progn (replace-regexp-in-string "\\\\{[^}]+}" #'(lambda (match) (substitute-command-keys match)) "\\{yas-minor-mode-map}"))
  elisp--eval-last-sexp(t)
  eval-last-sexp(t)
  eval-print-last-sexp(nil)
  funcall-interactively(eval-print-last-sexp nil)
  command-execute(eval-print-last-sexp)
```

This is what makes the function `yas--document-symbol` error out during documentation build (see #1147). This form must have been valid in previous versions of emacs.

This specific block of the function `yas--document-symbol` : 

```elisp
body (replace-regexp-in-string
                "\\\\{[^}]+}"
                (lambda (match)
                  (concat "#+BEGIN_EXAMPLE\n"
                          (substitute-command-keys match)
                          "#+END_EXAMPLE\n"))
                body t t)
```

aims to do two different things at once, namely enclosing strings like `\\{yas-minor-mode-map}` in an org-example block and substituting these strings with the pretty-formatted content  of said minor mode map. It would be more robust to do only one of those things at a time, at a cost of a second parsing of the string. On top that, the very next block of the same function : 

```elisp
          body (substitute-command-keys body)
```

does the substitution on the whole block, which makes the form `(substitute-command-keys match)` in the previous block unneeded.

The change in commiit c24c426 is therefore a simple fix to the documentation build failure, that does not change the output of the function `yas--document-symbol`.

(fix #1147)

Best,

Aymeric Agon-Rambosson
