### PR TITLE
Unbreak tests broken due to trampoline optimisation

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -35,6 +35,9 @@
 (require 'cl-lib)
 (require 'org)
 
+(with-eval-after-load 'comp
+  (push 'buffer-list native-comp-never-optimize-functions))
+
 
 ;;; Helper macros and function
 


### PR DESCRIPTION
The following three tests (among others, see #1125) fail with emacs 28+ : 
- 5/91 basic-jit-loading
- 6/91 basic-jit-loading-with-compiled-snippets
- 80/91 visiting-compiled-snippets

We know that the failure of these three tests is due to the trampoline compilation of primitive `buffer-list` that is made in the macro `yas-with-overriden-buffer-list`. We are not exactly sure why.

A possible way to solve this is to exclude this primitive from trampoline optimisation for the duration of the tests.

Best,

Aymeric Agon-Rambosson