### PR TITLE
Remove lisp-data-mode duplicate from tests

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -1396,9 +1396,7 @@ hello ${1:$(when (stringp yas-text) (funcall func yas-text))} foo${1:$$(concat \
                           ,@(if (fboundp 'lisp-data-mode)
                                 '(lisp-data-mode))
                           emacs-lisp-mode
-                          lisp-interaction-mode
-                          ;; `lisp-data-mode' doesn't exist prior to Emacs 28.
-                          ,@(and (fboundp 'lisp-data-mode) '(lisp-data-mode))))
+                          lisp-interaction-mode))
               (observed (yas--modes-to-activate)))
          (should (equal major-mode (car observed)))
          (should (equal (sort expected #'string<) (sort observed #'string<))))))))
@@ -1429,11 +1427,7 @@ hello ${1:$(when (stringp yas-text) (funcall func yas-text))} foo${1:$$(concat \
                                      '(lisp-data-mode))
                                emacs-lisp-mode
                                and-also-this-one
-                               lisp-interaction-mode
-                               ;; `lisp-data-mode' doesn't exist prior to
-                               ;; Emacs 28.
-                               ,@(and (fboundp 'lisp-data-mode)
-                                      '(lisp-data-mode))))
+                               lisp-interaction-mode))
               (observed (yas--modes-to-activate)))
          (should (equal expected-first
                         (cl-subseq observed 0 (length expected-first))))


### PR DESCRIPTION
Commit 1ca316fb added duplicates of `lisp-data-mode` into a list in tests 27 and 40 (`extra-modes-parenthood` and `loading-with-cyclic-parenthood` respectively, which breaks both tests.

This commit simply partly reverts commit 1ca316fb to get rid of the duplicate, and repairs both tests.

Best,

Aymeric