### PR TITLE
Allow closures in yas-buffer-local-condition

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1366,10 +1366,10 @@ conditions to filter out potential expansions."
       'always
     (let ((local-condition
            (or (cond
-                ((consp yas-buffer-local-condition)
-                 (yas--funcall-condition #'eval yas-buffer-local-condition t))
                 ((functionp yas-buffer-local-condition)
-                 (yas--funcall-condition yas-buffer-local-condition)))
+                 (yas--funcall-condition yas-buffer-local-condition))
+                ((consp yas-buffer-local-condition)
+                 (yas--funcall-condition #'eval yas-buffer-local-condition t)))
                yas-buffer-local-condition)))
       (when local-condition
         (if (eq local-condition t)


### PR DESCRIPTION
The change in introduced in [1d0966a](https://github.com/joaotavora/yasnippet/commit/1d0966ae34f392bcf5d22dc05276d5f9eea88adf) checks if `yas-buffer-local-condition` is a cons before a function but [lambdas in lexical environments get converted to closures](https://www.gnu.org/software/emacs/manual/html_node/elisp/Closures.html) which are also conses.

```elisp
ELISP> (setq x (lambda () "hello"))
(closure
    (t)
    nil "hello")

ELISP> (consp x)
t
ELISP> (functionp x)
t
ELISP> (eval x)
Debugger entered--Lisp error: (void-function closure)
```

This commit checks for functions first, to avoid evaling closures inadvertently.