### PR TITLE
Undo all-parents memoization in test

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -1438,6 +1438,7 @@ hello ${1:$(when (stringp yas-text) (funcall func yas-text))} foo${1:$$(concat \
   (yas-with-snippet-dirs '((".emacs.d/snippets"
                             ("yas--test-mode")))
     (yas-reload-all)
+    (put 'c-mode 'yas--all-parents nil)
     (with-temp-buffer
       (let* ((major-mode 'yas--test-mode)
              (expected `(fundamental-mode


### PR DESCRIPTION
yas-reload-all does not undo the memoization done in yas--all-parents, which causes the issue-492-and-494 test to fail when run after any tests that expands yas-with-some-interesting-snippet-dirs.

With the memoization enabled, c++-mode is considered a parent of c-mode, causing the issue-492-and-494 test to fail.  With the memoization reset, this does not occur.