### PR TITLE
(yas--all-parents): delete-dups for fundamental-mode

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -848,18 +848,19 @@ which decides on the snippet to expand.")
                             (cons (if (eq mode 'fundamental-mode) ()
                                     (append (cdr ap) '(fundamental-mode)))
                                   extras))))
-                 (cons mode
-                       (yas--merge-ordered-lists
-                        (mapcar #'yas--all-parents
-                                (remq nil
-                                      `(,(or (get mode 'derived-mode-parent)
-                                             ;; Consider `fundamental-mode'
-                                             ;; as ultimate ancestor.
-                                             'fundamental-mode)
-                                        ,(let ((alias (symbol-function mode)))
-                                           (when (symbolp alias) alias))
-                                        ,@(get mode 'derived-mode-extra-parents)
-                                        ,@(gethash mode yas--parents)))))))))
+                 (delete-dups
+                  (cons mode
+                        (yas--merge-ordered-lists
+                         (mapcar #'yas--all-parents
+                                 (remq nil
+                                       `(,(or (get mode 'derived-mode-parent)
+                                              ;; Consider `fundamental-mode'
+                                              ;; as ultimate ancestor.
+                                              'fundamental-mode)
+                                         ,(let ((alias (symbol-function mode)))
+                                            (when (symbolp alias) alias))
+                                         ,@(get mode 'derived-mode-extra-parents)
+                                         ,@(gethash mode yas--parents))))))))))
           (dolist (parent all-parents)
             (cl-pushnew mode (get parent 'yas--cached-children)))
           (put mode 'yas--all-parents all-parents)))))


### PR DESCRIPTION
Before this commit,

(yas--all-parents 'lisp-mode) would return:

`(lisp-mode lisp-data-mode prog-mode fundamental-mode fundamental-mode)`

which would cause duplicated entries when prompting (if the snippet were for fundamental-mode).