### PR TITLE
Function to load snippets without confirmation

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2824,6 +2824,23 @@ and `kill-buffer' instead."
         (save-buffer)))
     (quit-window kill)))
 
+  (defun yas-load-snippet-buffer-and-close-noconfirm()
+    "Load and save the snippet buffer and quit the window
+while selecting the default table, file path, and not prompting
+the user to save the buffer"
+    (interactive)
+    (unless yas--guessed-modes
+      (setq-local yas--guessed-modes (yas--compute-major-mode-and-parents buffer-file-name)))
+    (let ((template (yas-load-snippet-buffer (cl-first yas--guessed-modes) t)))
+      (when (buffer-modified-p)
+        (let ((default-directory (car (cdr (car (yas--guess-snippet-directories
+                                                 (yas--template-table template))))))
+              (default-file-name (yas--template-name template)))
+          (setq buffer-file-name (concat default-directory default-file-name))
+          (rename-buffer default-file-name t)
+          (save-buffer)))
+      (quit-window t)))
+
 (declare-function yas-debug-snippets "yasnippet-debug")
 
 (defun yas-tryout-snippet (&optional debug)


### PR DESCRIPTION
Yasnippet by default prompts the user to enter a table, file path to save the snippet, and if they want to save the buffer. 
I found myself almost always applying the defaults, so I wrote a function that saves the snippet, loads it, and quits without any confirmation.

## Testing

M-x `yas-new-snippet`
Fill in a snippet
M-x `yas-load-snippet-buffer-and-close-noconfirm
test that the snippet works