### PR TITLE
yasnippet.el(yas-minor-mode-on): autoload

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -974,6 +974,7 @@ per-mode exceptions to the \"global\" activation behaviour, call
 `yas-minor-mode' with a negative argument directily in the major
 mode's hook.") ;; FIXME: Why do we say "Only the global value is used"?
 
+;;;###autoload
 (defun yas-minor-mode-on ()
   "Turn on YASnippet minor mode.
 


### PR DESCRIPTION
My use-case requires passing that function to a hook, and it's much better to do that without loading the package.